### PR TITLE
Update ModEntry.cs

### DIFF
--- a/HereFishy/ModEntry.cs
+++ b/HereFishy/ModEntry.cs
@@ -335,6 +335,10 @@ namespace HereFishy
 			context.Monitor.Log($"caught fish end");
 			fishCaught = true;
 			fishQuality = Game1.random.Next(0, 5);
+			if (fishQuality == 3)
+			{
+				fishQuality = 0;
+			}
 			lastUser.Halt();
 			lastUser.armOffset = Vector2.Zero;
 


### PR DESCRIPTION
Fish quality 3 should be impossible. 0 is normal, 1 is silver, 2 is gold, 4 is iridium.
3 gives a bugged small gold star quality that sells for in between gold and iridium. This change makes you more likely to catch a normal fish instead.