### PR TITLE
Implemented animation frames

### DIFF
--- a/CustomChestTypes/CustomChestTypeData.cs
+++ b/CustomChestTypes/CustomChestTypeData.cs
@@ -16,7 +16,8 @@ namespace CustomChestTypes
         public int capacity;
         public int rows;
         public int price;
-        public Texture2D texture;
+        public IList<Texture2D> texture = new List<Texture2D>();
+        public int frames = 1;
         public string texturePath;
         public string description;
         public Rectangle boundingBox;


### PR DESCRIPTION
Backwards compatible additions to content format - 
"texturePath":"assets/Image{frame}.png"
"frames":(int)

The value of {frame} is replaced by the frame number (1 - frames), and is animated upon opening.