### PR TITLE
add back isInviting

### DIFF
--- a/MobilePhone/ModEntry.cs
+++ b/MobilePhone/ModEntry.cs
@@ -255,7 +255,7 @@ namespace MobilePhone
         private void Content_AssetRequested(object sender, StardewModdingAPI.Events.AssetRequestedEventArgs e)
         {
 
-            if (e.NameWithoutLocale.BaseName.Contains("Events"))
+            if (e.NameWithoutLocale.BaseName.Contains("Events") && isInviting)
             {
                 foreach (EventInvite invite in MobilePhoneCall.eventInvites)
                 {


### PR DESCRIPTION
(otherwise invitedNPC can be null)

specifically, it seems this Helper.Events.Content.AssetRequested event is triggered for every requested asset, including assets your mod does not own.