### PR TITLE
Garden Pot Tweaks Bugfix

### DIFF
--- a/GardenPotTweaks/GardenPotTweaks.csproj
+++ b/GardenPotTweaks/GardenPotTweaks.csproj
@@ -7,13 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Reference Include="FAudio-CS">
       <HintPath>H:\tmp\ga\SteamLibrary\steamapps\common\Stardew Valley\FAudio-CS.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
 

--- a/GardenPotTweaks/ModEntry.cs
+++ b/GardenPotTweaks/ModEntry.cs
@@ -39,7 +39,7 @@ namespace GardenPotTweaks
             Helper.Events.GameLoop.GameLaunched += GameLoop_GameLaunched;
 
             var harmony = new Harmony(ModManifest.UniqueID);
-            harmony.PatchAll();
+            PatchAll(harmony);
 
         }
 


### PR DESCRIPTION
I noticed that the current version of your Garden Pot Tweaks mod did not accurately show that a garden pot had been watered when it was handled by a sprinkler. I believe this is due to the fact that sprinklers have no logic to handle the sprite change of the garden pot. To get around that issue, I modified the routine to instead use a fake, bottomless Watering Can to water each tile the sprinkler detects. This modified logic seems to handle everything the way I expected it should.

I made some indirect changes in order to get the updated mod to load successfully in my game. Most notably, I converted from Harmony annotations to API calls since annotations are discouraged.