### PR TITLE
[AFKTimePause] Fix Freeze Game option

### DIFF
--- a/AFKTimePause/AFKMenu.cs
+++ b/AFKTimePause/AFKMenu.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Xna.Framework.Graphics;
 using StardewValley.Menus;
+using StardewValley;
+using StardewValley.BellsAndWhistles;
 
 namespace AFKTimePause
 {
@@ -9,7 +11,7 @@ namespace AFKTimePause
         {
             if (ModEntry.Config.ShowAFKText)
             {
-
+                SpriteText.drawStringWithScrollCenteredAt(b, ModEntry.Config.AFKText, Game1.viewport.Width / 2, Game1.viewport.Height / 2);
             }
         }
     }

--- a/AFKTimePause/CodePatches.cs
+++ b/AFKTimePause/CodePatches.cs
@@ -13,11 +13,6 @@ namespace AFKTimePause
             {
                 if (!Config.ModEnabled || !Game1.IsMasterGame || Game1.eventUp || Game1.isFestival() || elapsedSeconds < Config.SecondsTilAFK)
                     return true;
-                if(elapsedSeconds == Config.SecondsTilAFK)
-                {
-                    elapsedSeconds++;
-                    SMonitor.Log("Going AFK");
-                }
                 return false;
             }
         }

--- a/AFKTimePause/ModEntry.cs
+++ b/AFKTimePause/ModEntry.cs
@@ -53,13 +53,15 @@ namespace AFKTimePause
 
         private void Display_Rendered(object sender, StardewModdingAPI.Events.RenderedEventArgs e)
         {
-            if (!Config.ModEnabled || !Config.ShowAFKText || elapsedSeconds < Config.SecondsTilAFK || !Context.IsPlayerFree)
+            if (!Config.ModEnabled || !Config.ShowAFKText || Config.FreezeGame || elapsedSeconds < Config.SecondsTilAFK || !Context.IsPlayerFree)
                 return;
             SpriteText.drawStringWithScrollCenteredAt(e.SpriteBatch, Config.AFKText, Game1.viewport.Width / 2, Game1.viewport.Height / 2);
         }
 
         private void GameLoop_OneSecondUpdateTicked(object sender, StardewModdingAPI.Events.OneSecondUpdateTickedEventArgs e)
         {
+            if (Game1.activeClickableMenu is AFKMenu)
+                return;
             if (!Config.ModEnabled || !Context.IsPlayerFree || (Game1.player.CurrentTool is FishingRod && (Game1.player.CurrentTool as FishingRod).inUse()))
             {
                 elapsedSeconds = 0;
@@ -69,7 +71,6 @@ namespace AFKTimePause
             {
                 SMonitor.Log("Going AFK");
                 Game1.activeClickableMenu = new AFKMenu();
-                elapsedSeconds++;
             }
             else if (elapsedSeconds < Config.SecondsTilAFK)
                 elapsedSeconds++;


### PR DESCRIPTION
The increment of elapsedSeconds in the harmony patch and in the GameLoop_OneSecondUpdateTicked function changes the value of elapsedSeconds from SecondsTilAFK - 1 to SecondsTilAFK + 1. Thus, the condition `elapsedSeconds == Config.SecondsTilAFK && Config.FreezeGame` is always false and the AFK menu is never instantiated.
To fix this problem, the incremental part of the harmony patch has been removed and a condition has been added to block the GameLoop_OneSecondUpdateTicked function as long as the AFK menu is open.
Additionally, when the Freeze Game option is enabled, the AFK text is drawn directly into the AFK menu.