### PR TITLE
[AdvancedCooking] Fix tool duplication

### DIFF
--- a/AdvancedCooking/CodePatches.cs
+++ b/AdvancedCooking/CodePatches.cs
@@ -54,7 +54,7 @@ namespace AdvancedCooking
         }
         private static void CraftingPage_receiveLeftClick_Prefix(CraftingPage __instance, ref Item ___heldItem, int x, int y)
         {
-            if (!Config.EnableMod || Game1.activeClickableMenu is not CraftingPage || !AccessTools.FieldRefAccess<CraftingPage, bool>(Game1.activeClickableMenu as CraftingPage, "cooking"))
+            if (!Config.EnableMod || Game1.activeClickableMenu is not CraftingPage || !AccessTools.FieldRefAccess<CraftingPage, bool>(Game1.activeClickableMenu as CraftingPage, "cooking") || ___heldItem is Tool)
                 return;
             if (cookButton != null && cookButton.containsPoint(x, y))
             {

--- a/AdvancedCooking/ModEntry.cs
+++ b/AdvancedCooking/ModEntry.cs
@@ -475,7 +475,12 @@ namespace AdvancedCooking
         }
         private static bool IsCorrectIngredient(Item item, int key)
         {
-            return item is not null && !(item as Object).bigCraftable.Value && (((Object)item).ParentSheetIndex == key || ((Object)item).Category == key || CraftingRecipe.isThereSpecialIngredientRule((Object)item, key));
+            Object obj = item as Object;
+
+            if (obj is null)
+                return false;
+            else
+                return !obj.bigCraftable.Value && (obj.ParentSheetIndex == key || obj.Category == key || CraftingRecipe.isThereSpecialIngredientRule(obj, key));
         }
     }
 }


### PR DESCRIPTION
It is possible to place a tool in the ingredient bar, causing an error because the conversion of the Tool into an Object fails and interrupts the code execution, leaving one instance of the tool in the ingredient bar and another one being held.
The IsCorrectIngredient function has been modified to ensure that the Item can be converted into an Object, and the harmony patch has been modified to prevent tools from being placed in the ingredient bar.