### PR TITLE
[AdvancedMenuPositioning] Various fixes, improvements and features

### DIFF
--- a/AdvancedMenuPositioning/IGenericModConfigMenuApi.cs
+++ b/AdvancedMenuPositioning/IGenericModConfigMenuApi.cs
@@ -1,4 +1,5 @@
 ﻿using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
 using System;
 
 namespace AdvancedMenuPositioning
@@ -34,6 +35,15 @@ namespace AdvancedMenuPositioning
         /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
         /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
         void AddKeybind(IManifest mod, Func<SButton> getValue, Action<SButton> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
+
+        /// <summary>Add a key binding list at the current position in the form.</summary>
+        /// <param name="mod">The mod's manifest.</param>
+        /// <param name="getValue">Get the current value from the mod config.</param>
+        /// <param name="setValue">Set a new value in the mod config.</param>
+        /// <param name="name">The label text to show in the form.</param>
+        /// <param name="tooltip">The tooltip text shown when the cursor hovers on the field, or <c>null</c> to disable the tooltip.</param>
+        /// <param name="fieldId">The unique field ID for use with <see cref="OnFieldChanged"/>, or <c>null</c> to auto-generate a randomized ID.</param>
+        void AddKeybindList(IManifest mod, Func<KeybindList> getValue, Action<KeybindList> setValue, Func<string> name, Func<string> tooltip = null, string fieldId = null);
 
         /// <summary>Add a boolean option at the current position in the form.</summary>
         /// <param name="mod">The mod's manifest.</param>

--- a/AdvancedMenuPositioning/Methods.cs
+++ b/AdvancedMenuPositioning/Methods.cs
@@ -169,5 +169,25 @@ namespace AdvancedMenuPositioning
                 adjustedComponents.Add(c);
             }
         }
+
+        private static bool isKeybindPressed(SButton[] buttons)
+        {
+            if (!buttons.All(button => SHelper.Input.IsDown(button) || SHelper.Input.IsSuppressed(button)))
+                return false;
+            if (!Config.StrictKeybindings)
+                return true;
+
+            KeyboardState keyboardState = Game1.input.GetKeyboardState();
+            MouseState mouseState = Game1.input.GetMouseState();
+            GamePadState gamePadState = Game1.input.GetGamePadState();
+            int numberOfButtonsPressed = 0;
+
+            foreach (SButton button in Enum.GetValues(typeof(SButton)))
+            {
+                if (SHelper.Input.IsDown(button) || SHelper.Input.IsSuppressed(button))
+                    numberOfButtonsPressed++;
+            }
+            return numberOfButtonsPressed == buttons.Length;
+        }
     }
 }

--- a/AdvancedMenuPositioning/ModConfig.cs
+++ b/AdvancedMenuPositioning/ModConfig.cs
@@ -1,16 +1,14 @@
 ﻿
 using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
 
 namespace AdvancedMenuPositioning
 {
     public class ModConfig
     {
         public bool EnableMod { get; set; } = true;
-        public SButton DetachKey { get; set; } = SButton.X;
-        public SButton MoveKey { get; set; } = SButton.MouseLeft;
-        public SButton CloseKey { get; set; } = SButton.Z;
-        public SButton DetachModKey { get; set; } = SButton.LeftShift;
-        public SButton MoveModKey { get; set; } = SButton.LeftShift;
-        public SButton CloseModKey { get; set; } = SButton.LeftShift;
+        public KeybindList MoveKeys { get; set; } = new KeybindList(new Keybind(SButton.LeftShift, SButton.MouseLeft));
+        public KeybindList DetachKeys { get; set; } = new KeybindList(new Keybind(SButton.LeftShift, SButton.X));
+        public KeybindList CloseKeys { get; set; } = new KeybindList(new Keybind(SButton.LeftShift, SButton.Z));
     }
 }

--- a/AdvancedMenuPositioning/ModConfig.cs
+++ b/AdvancedMenuPositioning/ModConfig.cs
@@ -10,5 +10,6 @@ namespace AdvancedMenuPositioning
         public KeybindList MoveKeys { get; set; } = new KeybindList(new Keybind(SButton.LeftShift, SButton.MouseLeft));
         public KeybindList DetachKeys { get; set; } = new KeybindList(new Keybind(SButton.LeftShift, SButton.X));
         public KeybindList CloseKeys { get; set; } = new KeybindList(new Keybind(SButton.LeftShift, SButton.Z));
+        public bool StrictKeybindings { get; set; } = true;
     }
 }

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -59,9 +59,9 @@ namespace AdvancedMenuPositioning
         {
             if (!Context.IsWorldReady)
                 return;
-            foreach (var m in detachedMenus)
+            for (int i = detachedMenus.Count - 1; i >= 0; i--)
             {
-                m.receiveScrollWheelAction(e.Delta);
+                detachedMenus[i].receiveScrollWheelAction(e.Delta);
             }
         }
 
@@ -102,7 +102,7 @@ namespace AdvancedMenuPositioning
                     return;
                 if (Config.CloseKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)))
                 {
-                    for (int i = 0; i < detachedMenus.Count; i++)
+                    for (int i = detachedMenus.Count - 1; i >= 0; i--)
                     {
                         if(detachedMenus[i].isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                         {
@@ -115,7 +115,7 @@ namespace AdvancedMenuPositioning
                 }
                 if (Config.DetachKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)) && Game1.activeClickableMenu == null)
                 {
-                    for (int i = 0; i < detachedMenus.Count; i++)
+                    for (int i = detachedMenus.Count - 1; i >= 0; i--)
                     {
                         if(detachedMenus[i].isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                         {
@@ -131,7 +131,7 @@ namespace AdvancedMenuPositioning
                 {
                     if (Game1.activeClickableMenu is not null && Game1.activeClickableMenu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                         return;
-                    for (int i = 0; i < detachedMenus.Count; i++)
+                    for (int i = detachedMenus.Count - 1; i >= 0; i--)
                     {
                         bool toBreak = detachedMenus[i].isWithinBounds(Game1.getMouseX(), Game1.getMouseY());
 
@@ -144,6 +144,11 @@ namespace AdvancedMenuPositioning
                             detachedMenus[i] = Game1.activeClickableMenu;
                             AdjustMenu(detachedMenus[i], d, true);
                             Game1.activeClickableMenu = menu;
+                            if (toBreak)
+                            {
+                                detachedMenus.Add(detachedMenus[i]);
+                                detachedMenus.RemoveAt(i);
+                            }
                         }
                         else
                             detachedMenus.RemoveAt(i);
@@ -160,7 +165,7 @@ namespace AdvancedMenuPositioning
                 {
                     if (Game1.activeClickableMenu is not null && Game1.activeClickableMenu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                         return;
-                    for (int i = 0; i < detachedMenus.Count; i++)
+                    for (int i = detachedMenus.Count - 1; i >= 0; i--)
                     {
                         bool toBreak = detachedMenus[i].isWithinBounds(Game1.getMouseX(), Game1.getMouseY());
 
@@ -173,6 +178,11 @@ namespace AdvancedMenuPositioning
                             detachedMenus[i] = Game1.activeClickableMenu;
                             AdjustMenu(detachedMenus[i], d, true);
                             Game1.activeClickableMenu = menu;
+                            if (toBreak)
+                            {
+                                detachedMenus.Add(detachedMenus[i]);
+                                detachedMenus.RemoveAt(i);
+                            }
                         }
                         else
                             detachedMenus.RemoveAt(i);
@@ -207,28 +217,32 @@ namespace AdvancedMenuPositioning
                         goto next;
                     }
                 }
-                foreach (var menu in Game1.onScreenMenus)
+                for (int i = Game1.onScreenMenus.Count - 1; i >= 0; i--)
                 {
-                    if (menu is null)
+                    if (Game1.onScreenMenus[i] is null)
                         continue;
-                    if (currentlyDragging == menu || currentlyDragging is null && menu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
+                    if (currentlyDragging == Game1.onScreenMenus[i] || currentlyDragging is null && Game1.onScreenMenus[i].isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                     {
-                        currentlyDragging = menu;
+                        currentlyDragging = Game1.onScreenMenus[i];
 
-                        AdjustMenu(menu, Game1.getMousePosition() - lastMousePosition, true);
+                        Game1.onScreenMenus.Add(Game1.onScreenMenus[i]);
+                        Game1.onScreenMenus.RemoveAt(i);
+                        AdjustMenu(Game1.onScreenMenus[i], Game1.getMousePosition() - lastMousePosition, true);
                         Array.ForEach(Config.MoveKeys.Keybinds[0].Buttons, button => Helper.Input.Suppress(button));
                         goto next;
                     }
                 }
-                foreach (var menu in detachedMenus)
+                for (int i = detachedMenus.Count - 1; i >= 0; i--)
                 {
-                    if (menu is null)
+                    if (detachedMenus[i] is null)
                         continue;
-                    if (currentlyDragging == menu || currentlyDragging is null && menu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
+                    if (currentlyDragging == detachedMenus[i] || currentlyDragging is null && detachedMenus[i].isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                     {
-                        currentlyDragging = menu;
+                        currentlyDragging = detachedMenus[i];
 
-                        AdjustMenu(menu, Game1.getMousePosition() - lastMousePosition, true);
+                        detachedMenus.Add(detachedMenus[i]);
+                        detachedMenus.RemoveAt(i);
+                        AdjustMenu(detachedMenus[i], Game1.getMousePosition() - lastMousePosition, true);
                         Array.ForEach(Config.MoveKeys.Keybinds[0].Buttons, button => Helper.Input.Suppress(button));
                         goto next;
                     }

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -139,13 +139,9 @@ namespace AdvancedMenuPositioning
                         if (Game1.activeClickableMenu != null)
                         {
                             var d = new Point(detachedMenus[i].xPositionOnScreen - Game1.activeClickableMenu.xPositionOnScreen, detachedMenus[i].yPositionOnScreen - Game1.activeClickableMenu.yPositionOnScreen);
-                            if (d != Point.Zero)
-                            {
-                                detachedMenus[i] = Game1.activeClickableMenu;
-                                AdjustMenu(detachedMenus[i], d, true);
-                                Game1.activeClickableMenu = menu;
-                            }
-
+                            detachedMenus[i] = Game1.activeClickableMenu;
+                            AdjustMenu(detachedMenus[i], d, true);
+                            Game1.activeClickableMenu = menu;
                         }
                         else
                             detachedMenus.RemoveAt(i);
@@ -172,12 +168,9 @@ namespace AdvancedMenuPositioning
                         if (Game1.activeClickableMenu != null)
                         {
                             var d = new Point(detachedMenus[i].xPositionOnScreen - Game1.activeClickableMenu.xPositionOnScreen, detachedMenus[i].yPositionOnScreen - Game1.activeClickableMenu.yPositionOnScreen);
-                            if(d != Point.Zero)
-                            {
-                                detachedMenus[i] = Game1.activeClickableMenu;
-                                AdjustMenu(detachedMenus[i], d, true);
-                                Game1.activeClickableMenu = menu;
-                            }
+                            detachedMenus[i] = Game1.activeClickableMenu;
+                            AdjustMenu(detachedMenus[i], d, true);
+                            Game1.activeClickableMenu = menu;
                         }
                         else
                             detachedMenus.RemoveAt(i);

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -182,7 +182,7 @@ namespace AdvancedMenuPositioning
             {
                 if(Game1.activeClickableMenu != null)
                 {
-                    if (currentlyDragging == Game1.activeClickableMenu || Game1.activeClickableMenu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
+                    if (currentlyDragging == Game1.activeClickableMenu || currentlyDragging is null && Game1.activeClickableMenu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                     {
                         currentlyDragging = Game1.activeClickableMenu;
                         AdjustMenu(Game1.activeClickableMenu, Game1.getMousePosition() - lastMousePosition, true);
@@ -198,7 +198,7 @@ namespace AdvancedMenuPositioning
                 {
                     if (menu is null)
                         continue;
-                    if (currentlyDragging == menu || menu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
+                    if (currentlyDragging == menu || currentlyDragging is null && menu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                     {
                         currentlyDragging = menu;
 
@@ -211,7 +211,7 @@ namespace AdvancedMenuPositioning
                 {
                     if (menu is null)
                         continue;
-                    if (currentlyDragging == menu || menu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
+                    if (currentlyDragging == menu || currentlyDragging is null && menu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
                     {
                         currentlyDragging = menu;
 

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -338,32 +338,32 @@ namespace AdvancedMenuPositioning
 
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Mod Enabled",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModEnabled_Name"),
                 getValue: () => Config.EnableMod,
                 setValue: value => Config.EnableMod = value
             );
             configMenu.AddKeybindList(
                 mod: ModManifest,
-                name: () => "Move Keys",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_MoveKeys_Name"),
                 getValue: () => Config.MoveKeys,
                 setValue: value => Config.MoveKeys = value
             );
             configMenu.AddKeybindList(
                 mod: ModManifest,
-                name: () => "Detach Keys",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_DetachKeys_Name"),
                 getValue: () => Config.DetachKeys,
                 setValue: value => Config.DetachKeys = value
             );
             configMenu.AddKeybindList(
                 mod: ModManifest,
-                name: () => "Close Keys",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_CloseKeys_Name"),
                 getValue: () => Config.CloseKeys,
                 setValue: value => Config.CloseKeys = value
             );
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Strict Keys Enabled",
-                tooltip: () => "When enabled, strict key mode ensures that only the designated keys are pressed. This allows performing default game actions associated with those keys (e.g., in the crafting menu, LeftShift + MouseLeft will move the menu, and LeftShift + MouseLeft + AnyOtherKey will craft 5 items at a time).",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_StrictKeybindings_Name"),
+                tooltip: () => ModEntry.SHelper.Translation.Get("GMCM_Option_StrictKeybindings_Tooltip"),
                 getValue: () => Config.StrictKeybindings,
                 setValue: value => Config.StrictKeybindings = value
             );

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -88,7 +88,7 @@ namespace AdvancedMenuPositioning
         {
             if (!Context.IsWorldReady || !Config.EnableMod)
                 return;
-            if (Game1.activeClickableMenu != null && Config.DetachKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)) && new Rectangle(Game1.activeClickableMenu.xPositionOnScreen, Game1.activeClickableMenu.yPositionOnScreen, Game1.activeClickableMenu.width, Game1.activeClickableMenu.height).Contains(Game1.getMouseX(), Game1.getMouseY()))
+            if (Game1.activeClickableMenu != null && isKeybindPressed(Config.DetachKeys.Keybinds[0].Buttons) && new Rectangle(Game1.activeClickableMenu.xPositionOnScreen, Game1.activeClickableMenu.yPositionOnScreen, Game1.activeClickableMenu.width, Game1.activeClickableMenu.height).Contains(Game1.getMouseX(), Game1.getMouseY()))
             {
                 detachedMenus.Add(Game1.activeClickableMenu);
                 Game1.activeClickableMenu = null;
@@ -98,9 +98,9 @@ namespace AdvancedMenuPositioning
             }
             else if(detachedMenus.Count > 0)
             {
-                if (Config.MoveKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)))
+                if (isKeybindPressed(Config.MoveKeys.Keybinds[0].Buttons))
                     return;
-                if (Config.CloseKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)))
+                if (isKeybindPressed(Config.CloseKeys.Keybinds[0].Buttons))
                 {
                     for (int i = detachedMenus.Count - 1; i >= 0; i--)
                     {
@@ -113,7 +113,7 @@ namespace AdvancedMenuPositioning
                         }
                     }
                 }
-                if (Config.DetachKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)) && Game1.activeClickableMenu == null)
+                if (isKeybindPressed(Config.DetachKeys.Keybinds[0].Buttons) && Game1.activeClickableMenu == null)
                 {
                     for (int i = detachedMenus.Count - 1; i >= 0; i--)
                     {
@@ -199,9 +199,9 @@ namespace AdvancedMenuPositioning
 
         private void GameLoop_UpdateTicking(object sender, StardewModdingAPI.Events.UpdateTickingEventArgs e)
         {
-            if (!Context.IsWorldReady)
+            if (!Context.IsWorldReady || !Config.EnableMod)
                 return;
-            if(Config.EnableMod && Config.MoveKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)))
+            if(isKeybindPressed(Config.MoveKeys.Keybinds[0].Buttons))
             {
                 if(Game1.activeClickableMenu != null)
                 {
@@ -298,6 +298,13 @@ namespace AdvancedMenuPositioning
                 name: () => "Close Keys",
                 getValue: () => Config.CloseKeys,
                 setValue: value => Config.CloseKeys = value
+            );
+            configMenu.AddBoolOption(
+                mod: ModManifest,
+                name: () => "Strict Keys Enabled",
+                tooltip: () => "When enabled, strict key mode ensures that only the designated keys are pressed. This allows performing default game actions associated with those keys (e.g., in the crafting menu, LeftShift + MouseLeft will move the menu, and LeftShift + MouseLeft + AnyOtherKey will craft 5 items at a time).",
+                getValue: () => Config.StrictKeybindings,
+                setValue: value => Config.StrictKeybindings = value
             );
         }
    }

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -127,6 +127,8 @@ namespace AdvancedMenuPositioning
                 }
                 else if (e.Button == SButton.MouseLeft)
                 {
+                    if (Game1.activeClickableMenu is not null && Game1.activeClickableMenu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
+                        return;
                     for (int i = 0; i < detachedMenus.Count; i++)
                     {
                         bool toBreak = detachedMenus[i].isWithinBounds(Game1.getMouseX(), Game1.getMouseY());
@@ -158,6 +160,8 @@ namespace AdvancedMenuPositioning
                 }
                 else if (e.Button == SButton.MouseRight)
                 {
+                    if (Game1.activeClickableMenu is not null && Game1.activeClickableMenu.isWithinBounds(Game1.getMouseX(), Game1.getMouseY()))
+                        return;
                     for (int i = 0; i < detachedMenus.Count; i++)
                     {
                         bool toBreak = detachedMenus[i].isWithinBounds(Game1.getMouseX(), Game1.getMouseY());

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -88,7 +88,7 @@ namespace AdvancedMenuPositioning
         {
             if (!Context.IsWorldReady || !Config.EnableMod)
                 return;
-            if (Game1.activeClickableMenu != null && Helper.Input.IsDown(Config.DetachModKey) && e.Button == Config.DetachKey && new Rectangle(Game1.activeClickableMenu.xPositionOnScreen, Game1.activeClickableMenu.yPositionOnScreen, Game1.activeClickableMenu.width, Game1.activeClickableMenu.height).Contains(Game1.getMouseX(), Game1.getMouseY()))
+            if (Game1.activeClickableMenu != null && Config.DetachKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)) && new Rectangle(Game1.activeClickableMenu.xPositionOnScreen, Game1.activeClickableMenu.yPositionOnScreen, Game1.activeClickableMenu.width, Game1.activeClickableMenu.height).Contains(Game1.getMouseX(), Game1.getMouseY()))
             {
                 detachedMenus.Add(Game1.activeClickableMenu);
                 Game1.activeClickableMenu = null;
@@ -98,9 +98,9 @@ namespace AdvancedMenuPositioning
             }
             else if(detachedMenus.Count > 0)
             {
-                if (Helper.Input.IsDown(Config.MoveModKey) && (Helper.Input.IsDown(Config.MoveKey) || Helper.Input.IsSuppressed(Config.MoveKey)))
+                if (Config.MoveKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)))
                     return;
-                if (Helper.Input.IsDown(Config.CloseModKey) && e.Button == Config.CloseKey)
+                if (Config.CloseKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)))
                 {
                     for (int i = 0; i < detachedMenus.Count; i++)
                     {
@@ -113,7 +113,7 @@ namespace AdvancedMenuPositioning
                         }
                     }
                 }
-                if (Helper.Input.IsDown(Config.DetachModKey) && e.Button == Config.DetachKey && Game1.activeClickableMenu == null)
+                if (Config.DetachKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)) && Game1.activeClickableMenu == null)
                 {
                     for (int i = 0; i < detachedMenus.Count; i++)
                     {
@@ -191,7 +191,7 @@ namespace AdvancedMenuPositioning
         {
             if (!Context.IsWorldReady)
                 return;
-            if(Config.EnableMod && Helper.Input.IsDown(Config.MoveModKey) && (Helper.Input.IsDown(Config.MoveKey) || Helper.Input.IsSuppressed(Config.MoveKey)))
+            if(Config.EnableMod && Config.MoveKeys.Keybinds[0].Buttons.All(button => Helper.Input.IsDown(button) || Helper.Input.IsSuppressed(button)))
             {
                 if(Game1.activeClickableMenu != null)
                 {
@@ -199,7 +199,7 @@ namespace AdvancedMenuPositioning
                     {
                         currentlyDragging = Game1.activeClickableMenu;
                         AdjustMenu(Game1.activeClickableMenu, Game1.getMousePosition() - lastMousePosition, true);
-                        Helper.Input.Suppress(Config.MoveKey);
+                        Array.ForEach(Config.MoveKeys.Keybinds[0].Buttons, button => Helper.Input.Suppress(button));
                         if (Game1.activeClickableMenu is ItemGrabMenu && Helper.ModRegistry.IsLoaded("Pathoschild.ChestsAnywhere"))
                         {
                             Game1.activeClickableMenu = Game1.activeClickableMenu.ShallowClone();
@@ -216,7 +216,7 @@ namespace AdvancedMenuPositioning
                         currentlyDragging = menu;
 
                         AdjustMenu(menu, Game1.getMousePosition() - lastMousePosition, true);
-                        Helper.Input.Suppress(Config.MoveKey);
+                        Array.ForEach(Config.MoveKeys.Keybinds[0].Buttons, button => Helper.Input.Suppress(button));
                         goto next;
                     }
                 }
@@ -229,7 +229,7 @@ namespace AdvancedMenuPositioning
                         currentlyDragging = menu;
 
                         AdjustMenu(menu, Game1.getMousePosition() - lastMousePosition, true);
-                        Helper.Input.Suppress(Config.MoveKey);
+                        Array.ForEach(Config.MoveKeys.Keybinds[0].Buttons, button => Helper.Input.Suppress(button));
                         goto next;
                     }
                 }
@@ -267,41 +267,23 @@ namespace AdvancedMenuPositioning
                 getValue: () => Config.EnableMod,
                 setValue: value => Config.EnableMod = value
             );
-            configMenu.AddKeybind(
+            configMenu.AddKeybindList(
                 mod: ModManifest,
-                name: () => "Move Key",
-                getValue: () => Config.MoveKey,
-                setValue: value => Config.MoveKey = value
+                name: () => "Move Keys",
+                getValue: () => Config.MoveKeys,
+                setValue: value => Config.MoveKeys = value
             );
-            configMenu.AddKeybind(
+            configMenu.AddKeybindList(
                 mod: ModManifest,
-                name: () => "Detach Key",
-                getValue: () => Config.DetachKey,
-                setValue: value => Config.DetachKey = value
+                name: () => "Detach Keys",
+                getValue: () => Config.DetachKeys,
+                setValue: value => Config.DetachKeys = value
             );
-            configMenu.AddKeybind(
+            configMenu.AddKeybindList(
                 mod: ModManifest,
-                name: () => "Close Key",
-                getValue: () => Config.CloseKey,
-                setValue: value => Config.CloseKey = value
-            );
-            configMenu.AddKeybind(
-                mod: ModManifest,
-                name: () => "Move Mod Key",
-                getValue: () => Config.MoveModKey,
-                setValue: value => Config.MoveModKey = value
-            );
-            configMenu.AddKeybind(
-                mod: ModManifest,
-                name: () => "DetachModKey Key",
-                getValue: () => Config.DetachModKey,
-                setValue: value => Config.DetachModKey = value
-            );
-            configMenu.AddKeybind(
-                mod: ModManifest,
-                name: () => "CloseModKey Key",
-                getValue: () => Config.CloseModKey,
-                setValue: value => Config.CloseModKey = value
+                name: () => "Close Keys",
+                getValue: () => Config.CloseKeys,
+                setValue: value => Config.CloseKeys = value
             );
         }
    }

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -49,6 +49,8 @@ namespace AdvancedMenuPositioning
 
         private void Input_MouseWheelScrolled(object sender, StardewModdingAPI.Events.MouseWheelScrolledEventArgs e)
         {
+            if (!Context.IsWorldReady)
+                return;
             foreach (var m in detachedMenus)
             {
                 m.receiveScrollWheelAction(e.Delta);
@@ -57,6 +59,8 @@ namespace AdvancedMenuPositioning
 
         private void Display_RenderedWorld(object sender, StardewModdingAPI.Events.RenderedWorldEventArgs e)
         {
+            if (!Context.IsWorldReady)
+                return;
             if (detachedMenus.Any())
             {
                 var back = Game1.options.showMenuBackground;
@@ -74,7 +78,7 @@ namespace AdvancedMenuPositioning
 
         private void Input_ButtonPressed(object sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)
         {
-            if (!Config.EnableMod)
+            if (!Context.IsWorldReady || !Config.EnableMod)
                 return;
             if (Game1.activeClickableMenu != null && Helper.Input.IsDown(Config.DetachModKey) && e.Button == Config.DetachKey && new Rectangle(Game1.activeClickableMenu.xPositionOnScreen, Game1.activeClickableMenu.yPositionOnScreen, Game1.activeClickableMenu.width, Game1.activeClickableMenu.height).Contains(Game1.getMouseX(), Game1.getMouseY()))
             {
@@ -178,6 +182,8 @@ namespace AdvancedMenuPositioning
 
         private void GameLoop_UpdateTicking(object sender, StardewModdingAPI.Events.UpdateTickingEventArgs e)
         {
+            if (!Context.IsWorldReady)
+                return;
             if(Config.EnableMod && Helper.Input.IsDown(Config.MoveModKey) && (Helper.Input.IsDown(Config.MoveKey) || Helper.Input.IsSuppressed(Config.MoveKey)))
             {
                 if(Game1.activeClickableMenu != null)

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -41,10 +41,18 @@ namespace AdvancedMenuPositioning
 
             helper.Events.GameLoop.GameLaunched += GameLoop_GameLaunched;
             helper.Events.GameLoop.UpdateTicking += GameLoop_UpdateTicking;
+            helper.Events.GameLoop.ReturnedToTitle += GameLoop_ReturnedToTitle;
             helper.Events.Input.ButtonPressed += Input_ButtonPressed;
             helper.Events.Input.MouseWheelScrolled += Input_MouseWheelScrolled;
             helper.Events.Display.RenderedWorld += Display_RenderedWorld;
 
+        }
+
+        private void GameLoop_ReturnedToTitle(object sender, StardewModdingAPI.Events.ReturnedToTitleEventArgs e)
+        {
+            adjustedComponents.Clear();
+            adjustedMenus.Clear();
+            detachedMenus.Clear();
         }
 
         private void Input_MouseWheelScrolled(object sender, StardewModdingAPI.Events.MouseWheelScrolledEventArgs e)

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -98,6 +98,8 @@ namespace AdvancedMenuPositioning
             }
             else if(detachedMenus.Count > 0)
             {
+                if (Helper.Input.IsDown(Config.MoveModKey) && (Helper.Input.IsDown(Config.MoveKey) || Helper.Input.IsSuppressed(Config.MoveKey)))
+                    return;
                 if (Helper.Input.IsDown(Config.CloseModKey) && e.Button == Config.CloseKey)
                 {
                     for (int i = 0; i < detachedMenus.Count; i++)

--- a/AdvancedMenuPositioning/ModEntry.cs
+++ b/AdvancedMenuPositioning/ModEntry.cs
@@ -7,6 +7,7 @@ using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Objects;
 using System;
+using System.Reflection;
 using System.Collections.Generic;
 using System.Linq;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
@@ -140,6 +141,9 @@ namespace AdvancedMenuPositioning
                         var menu = Game1.activeClickableMenu;
                         Game1.activeClickableMenu = detachedMenus[i];
                         Game1.activeClickableMenu.receiveLeftClick(Game1.getMouseX(), Game1.getMouseY());
+                        ItemGrabMenu menuAsItemGrabMenu = Game1.activeClickableMenu as ItemGrabMenu;
+                        if (menuAsItemGrabMenu is not null)
+                            Game1.activeClickableMenu = (IClickableMenu) new ItemGrabMenu(menuAsItemGrabMenu.ItemsToGrabMenu.actualInventory, false, true, new InventoryMenu.highlightThisItem(InventoryMenu.highlightAllItems), (ItemGrabMenu.behaviorOnItemSelect)typeof(ItemGrabMenu).GetField("behaviorFunction", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(menuAsItemGrabMenu), (string) null, menuAsItemGrabMenu.behaviorOnItemGrab, canBeExitedWithKey: true, showOrganizeButton: true, source: menuAsItemGrabMenu.source, sourceItem: (Item)typeof(ItemGrabMenu).GetField("sourceItem", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(menuAsItemGrabMenu), whichSpecialButton: menuAsItemGrabMenu.whichSpecialButton, context: menuAsItemGrabMenu.context).setEssential((bool)typeof(ItemGrabMenu).GetField("essential", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(menuAsItemGrabMenu));
                         if (Game1.activeClickableMenu != null)
                         {
                             var d = new Point(detachedMenus[i].xPositionOnScreen - Game1.activeClickableMenu.xPositionOnScreen, detachedMenus[i].yPositionOnScreen - Game1.activeClickableMenu.yPositionOnScreen);

--- a/AdvancedMenuPositioning/i18n/default.json
+++ b/AdvancedMenuPositioning/i18n/default.json
@@ -1,0 +1,9 @@
+{
+  // GMCM
+  "GMCM_Option_ModEnabled_Name": "Mod Enabled",
+  "GMCM_Option_MoveKeys_Name": "Move Keys",
+  "GMCM_Option_DetachKeys_Name": "Detach Keys",
+  "GMCM_Option_CloseKeys_Name": "Close Keys",
+  "GMCM_Option_StrictKeybindings_Name": "Strict Keys Enabled",
+  "GMCM_Option_StrictKeybindings_Tooltip": "When enabled, strict key mode ensures that only the designated keys are pressed. This allows performing default game actions associated with those keys (e.g., in the crafting menu, LeftShift + MouseLeft will move the menu, and LeftShift + MouseLeft + AnyOtherKey will craft 5 items at a time)."
+}

--- a/AdvancedMenuPositioning/i18n/fr.json
+++ b/AdvancedMenuPositioning/i18n/fr.json
@@ -1,0 +1,9 @@
+{
+  // GMCM
+  "GMCM_Option_ModEnabled_Name": "Activer le Mod",
+  "GMCM_Option_MoveKeys_Name": "Touches pour déplacer",
+  "GMCM_Option_DetachKeys_Name": "Touches pour détacher",
+  "GMCM_Option_CloseKeys_Name": "Touches pour fermer",
+  "GMCM_Option_StrictKeybindings_Name": "Activer les raccourcis stricts",
+  "GMCM_Option_StrictKeybindings_Tooltip": "Lorsque activé, le mode de raccourcis stricts garantit que seules les touches désignées sont appuyées. Cela permet d'effectuer les actions par défaut du jeu associées à ces touches (par exemple, dans le menu de fabrication, MajGauche + ClicGauche déplacera le menu, et MajGauche + ClicGauche + UneAutreTouche fabriquera 5 objets à la fois)."
+}


### PR DESCRIPTION
### Fixes:
* (dd64014f44fab12b0782e898c7dc5a1c76c3edd0) When one menu is moved over another, it can cause the menu being moved to change unexpectedly.
A check has been added to ensure that the menu being moved does not change if there is already a menu being dragged.
* (83a7be389630796a97ba6a29698765fc9365e042) It is possible to move menus from the title screen. However, doing so can cause display issues and leave the user unable to interact with the game if the buttons are moved outside the screen.
A check has been added to disable the core functions of the mod until a save is loaded.
* (a5fd78333be9446764f39cb15b6706daaa3915fe) It is possible to return to the title screen and even load another save with detached menus open, which can cause confusion.
Instructions have been added to close all detached menus when returning to the title screen.
* (9299327430561fd1ad1cf872fb770e4ada9d1995) When a detached menu is behind an active menu, clicks can be intercepted by the detached menu, making the active menu unusable.
A check has been added to ignore the mod when the cursor is pointing to an active menu. This ensures that the game can handle the click and that the active menu remains usable.
* (3f2d291b882df3943cc2ee2fc9de0667b9be9660) When a chest menu is opened, detached, and used without being moved, the condition `d != Point.Zero` is false, causing issues when using the chest where the reference to the same item gets duplicated and the same item occupies several slots. Although the cause of this issue is unclear, omitting the three lines of code inside the block of the `d != Point.Zero` condition can completely break the chest menu until it is moved or reattached.
To fix this bug, the condition `d != Point.Zero` has been removed.
* (f42a8179ef5f17c07b2ef8f30cbae21195485787) When moving a menu, pressing the move keys triggers the `Input_ButtonPressed` function which can cause unwanted side actions.
A condition has been added to avoid this.
* (1ce645b6e22c1c72eb560acb1b91605fdc642bca) When the 'Add to existing stacks' button is used on a detached menu, 0 units of the object remain in the inventory (the icon of the item remains in the inventory when it is no longer there).
Instructions have been added to recreate a menu from the existing menu, resetting the display.

### Improvements:
* (ebbc8351cd43501dbc18251f1b1e7228d9b7bee6) The mod options have been simplified by using KeybindList instead of Sbuttons to specify the keys for each action.
* (6ca87463f29f5bf93391567d071ef17ccb6d441b) Several loops have been reversed and instructions have been added when the player interacts with a menu to change its position in the list of detached menus. The menus the player interacts with are pushed to the foreground and the actions are intercepted from the foreground menus to the background menus.
* (4f25e801174e77327675a7cb521f6c8f000b9ebc) A Strict Key option has been added to the GMCM menu to avoid conflicts between the mod keys and the game default keys. When enabled, strict key mode ensures that only designated keys are pressed. This allows the default game actions associated with those keys to be performed (for example, in the crafting menu, **LeftShift + LeftMouse** will move the menu, and **LeftShift + LeftMouse + AnyOtherKey** will craft 5 items at once).
* (058c3313c499d29bf41c443d91d5cdcb43c912f2) A function triggered by `UpdateTicking` has been added to send the right click to the detached menus as in `Input_ButtonPressed`, using a `RightClickLimiter` to simulate the default behavior of a long press. The initialization of the long press requires 30 ticks (0.5s) then a right click is sent every 3 ticks (0.05s).

### Features:
* (ac954c6a65da56856c24082acbf795dde38d1a3c) Translation support has been added for the GMCM menu
* (2716854ffdd67cec62254f4ce96c4507e6f3a7a2) French translation has been added