### PR TITLE
[AllChestsMenu] Various fixes, improvements and features

### DIFF
--- a/AllChestsMenu/Methods.cs
+++ b/AllChestsMenu/Methods.cs
@@ -13,7 +13,7 @@ namespace AllChestsMenu
             if (Config.ModEnabled && Context.IsPlayerFree)
             {
                 Game1.activeClickableMenu = new StorageMenu();
-				Game1.playSound("bigSelect");
+                Game1.playSound("bigSelect");
             }
         }
     }

--- a/AllChestsMenu/Methods.cs
+++ b/AllChestsMenu/Methods.cs
@@ -13,6 +13,7 @@ namespace AllChestsMenu
             if (Config.ModEnabled && Context.IsPlayerFree)
             {
                 Game1.activeClickableMenu = new StorageMenu();
+				Game1.playSound("bigSelect");
             }
         }
     }

--- a/AllChestsMenu/ModEntry.cs
+++ b/AllChestsMenu/ModEntry.cs
@@ -118,15 +118,15 @@ namespace AllChestsMenu
                 mod: ModManifest,
                 name: () => "Mod Key 2",
                 tooltip: () => "Hold down to transfer only same items when transfering all",
-                getValue: () => Config.SwitchButton,
-                setValue: value => Config.SwitchButton = value
+                getValue: () => Config.ModKey2,
+                setValue: value => Config.ModKey2 = value
             );
             configMenu.AddKeybind(
                 mod: ModManifest,
                 name: () => "Switch Button",
                 tooltip: () => "For controllers to switch between upper and lower interfaces",
                 getValue: () => Config.SwitchButton,
-                setValue: value => Config.ModKey2 = value
+                setValue: value => Config.SwitchButton = value
             );
         }
 

--- a/AllChestsMenu/ModEntry.cs
+++ b/AllChestsMenu/ModEntry.cs
@@ -84,47 +84,47 @@ namespace AllChestsMenu
 
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Mod Enabled",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModEnabled_Name"),
                 getValue: () => Config.ModEnabled,
                 setValue: value => Config.ModEnabled = value
             );
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Current Loc Only",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_LimitToCurrentLocation_Name"),
                 getValue: () => Config.LimitToCurrentLocation,
                 setValue: value => Config.LimitToCurrentLocation = value
             );
             configMenu.AddKeybind(
                 mod: ModManifest,
-                name: () => "Menu Key",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_MenuKey_Name"),
                 getValue: () => Config.MenuKey,
                 setValue: value => Config.MenuKey = value
             );
 
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Req. Mod Key To Open",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModToOpen_Name"),
                 getValue: () => Config.ModToOpen,
                 setValue: value => Config.ModToOpen = value
             );
             configMenu.AddKeybind(
                 mod: ModManifest,
-                name: () => "Mod Key",
-                tooltip: () => "Hold down to open menu and to transfer contents instead of swapping menus",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModKey_Name"),
+                tooltip: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModKey_Tooltip"),
                 getValue: () => Config.ModKey,
                 setValue: value => Config.ModKey = value
             );
             configMenu.AddKeybind(
                 mod: ModManifest,
-                name: () => "Mod Key 2",
-                tooltip: () => "Hold down to transfer only same items when transfering all",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModKey2_Name"),
+                tooltip: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModKey2_Tooltip"),
                 getValue: () => Config.ModKey2,
                 setValue: value => Config.ModKey2 = value
             );
             configMenu.AddKeybind(
                 mod: ModManifest,
-                name: () => "Switch Button",
-                tooltip: () => "For controllers to switch between upper and lower interfaces",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_SwitchButton_Name"),
+                tooltip: () => ModEntry.SHelper.Translation.Get("GMCM_Option_SwitchButton_Tooltip"),
                 getValue: () => Config.SwitchButton,
                 setValue: value => Config.SwitchButton = value
             );

--- a/AllChestsMenu/StorageMenu.cs
+++ b/AllChestsMenu/StorageMenu.cs
@@ -86,7 +86,6 @@ namespace AllChestsMenu
         public string filterString;
         public string nameString;
         public string fridgeString;
-        public string storeSimilarString;
         private string sortString;
 
         public StorageMenu() : base(Game1.uiViewport.Width / 2 - (windowWidth + borderWidth * 2) / 2, -borderWidth - 64, 64 * 26 + 4 + borderWidth * 2, Game1.uiViewport.Height + borderWidth * 2 + 64, false)
@@ -108,7 +107,6 @@ namespace AllChestsMenu
             filterString = ModEntry.SHelper.Translation.Get("filter");
             nameString = ModEntry.SHelper.Translation.Get("name");
             fridgeString = ModEntry.SHelper.Translation.Get("fridge");
-            storeSimilarString = ModEntry.SHelper.Translation.Get("store-similar");
             sortString = ModEntry.SHelper.Translation.Get("sort");
 
             var columns = 12;
@@ -118,7 +116,7 @@ namespace AllChestsMenu
             playerInventoryMenu = new InventoryMenu((Game1.uiViewport.Width - 64 * columns) / 2, Game1.uiViewport.Height - 64 * 3 - borderWidth / 2, false, Game1.player.Items, null, cap, rows);
             SetPlayerInventoryNeighbours();
 
-            trashCan = new ClickableTextureComponent(new Rectangle(playerInventoryMenu.xPositionOnScreen + playerInventoryMenu.width + 64 + 32, playerInventoryMenu.yPositionOnScreen + 64 + 16, 64, 104), Game1.mouseCursors, new Rectangle(564 + Game1.player.trashCanLevel * 18, 102, 18, 26), 4f, false)
+            trashCan = new ClickableTextureComponent(new Rectangle(playerInventoryMenu.xPositionOnScreen + playerInventoryMenu.width + 64 + 32 + 8, playerInventoryMenu.yPositionOnScreen + 64 + 16, 64, 104), Game1.mouseCursors, new Rectangle(564 + Game1.player.trashCanLevel * 18, 102, 18, 26), 4f, false)
             {
                 myID = 4 * ccMagnitude + 2,
                 leftNeighborID = 11,
@@ -132,7 +130,7 @@ namespace AllChestsMenu
                 leftNeighborID = 11,
                 rightNeighborID = 4 * ccMagnitude + 1
             };
-            storeAlikeButton =  new ClickableTextureComponent("", new Rectangle(playerInventoryMenu.xPositionOnScreen + playerInventoryMenu.width + 64 + 64, playerInventoryMenu.yPositionOnScreen, 64, 64), "", storeSimilarString, Game1.mouseCursors, new Rectangle(419, 456, 14, 14), 4f, false)
+            storeAlikeButton =  new ClickableTextureComponent("", new Rectangle(playerInventoryMenu.xPositionOnScreen + playerInventoryMenu.width + 64 + 64 + 16, playerInventoryMenu.yPositionOnScreen, 64, 64), "", Game1.content.LoadString("Strings\\UI:ItemGrab_FillStacks"), Game1.mouseCursors, new Rectangle(103, 469, 16, 16), 4f, false)
             {
                 myID = 4 * ccMagnitude + 1,
                 downNeighborID = 4 * ccMagnitude + 2,
@@ -181,7 +179,7 @@ namespace AllChestsMenu
                 string name = s[i];
                 sortNames[name] = ModEntry.SHelper.Translation.Get("sort-" + name);
                 int idx = 5 * ccMagnitude;
-                sortCCList.Add(new ClickableComponent(new Rectangle(organizeButton.bounds.X + 156 + i / 2 * 48, organizeButton.bounds.Y + 64 + row * 48, 32, 32), name, name)
+                sortCCList.Add(new ClickableComponent(new Rectangle(organizeButton.bounds.X + 156 + i / 2 * 48 + 32, organizeButton.bounds.Y + 64 + row * 48 + 16, 32, 32), name, name)
                 {
                     myID = idx + i,
                     leftNeighborID = i > 2 ? idx + i - 2: 4 * ccMagnitude + 1,
@@ -439,7 +437,7 @@ namespace AllChestsMenu
                 renameBox.Draw(b);
                 okButton.draw(b);
             }
-            SpriteText.drawStringHorizontallyCenteredAt(b, sortString, organizeButton.bounds.X + 156 + 32 * 2 + 24, organizeButton.bounds.Y);
+            SpriteText.drawStringHorizontallyCenteredAt(b, sortString, organizeButton.bounds.X + 156 + 32 * 2 + 24 + 32, organizeButton.bounds.Y + 16);
             foreach(var cc in sortCCList)
             {
                 b.DrawString(Game1.smallFont, cc.label, cc.bounds.Location.ToVector2() + new Vector2(-1, 1), currentSort.ToString() == cc.label ? Color.Green : Color.Black);

--- a/AllChestsMenu/StorageMenu.cs
+++ b/AllChestsMenu/StorageMenu.cs
@@ -1105,8 +1105,16 @@ namespace AllChestsMenu
 
         private void RenameStorage()
         {
-            allStorageList[renamingStorage.index].chest.modData[chestsAnywhereKey] = renameBox.Text;
-            allStorageList[renamingStorage.index].label = $"{renameBox.Text} ({renamingStorage.location} {(renamingStorage.tile.X > -1 ? renamingStorage.tile.X + "," + renamingStorage.tile.Y : fridgeString)})";
+            if (string.IsNullOrEmpty(renameBox.Text))
+            {
+                allStorageList[renamingStorage.index].chest.modData[chestsAnywhereKey] = "";
+                allStorageList[renamingStorage.index].label = $"{renamingStorage.location} {(renamingStorage.tile.X > -1 ? renamingStorage.tile.X + "," + renamingStorage.tile.Y : fridgeString)}";
+            }
+            else
+            {
+                allStorageList[renamingStorage.index].chest.modData[chestsAnywhereKey] = renameBox.Text;
+                allStorageList[renamingStorage.index].label = $"{renameBox.Text} ({renamingStorage.location} {(renamingStorage.tile.X > -1 ? renamingStorage.tile.X + "," + renamingStorage.tile.Y : fridgeString)})";
+            }
             renamingStorage = null;
             renameBox.Selected = false;
             Game1.playSound("bigSelect");

--- a/AllChestsMenu/StorageMenu.cs
+++ b/AllChestsMenu/StorageMenu.cs
@@ -88,7 +88,7 @@ namespace AllChestsMenu
         public string fridgeString;
         private string sortString;
 
-		public StorageMenu() : base(Game1.uiViewport.Width / 2 - (windowWidth + borderWidth * 2) / 2, -borderWidth - 64, windowWidth + borderWidth * 2, Game1.uiViewport.Height + borderWidth * 2 + 64, false)
+        public StorageMenu() : base(Game1.uiViewport.Width / 2 - (windowWidth + borderWidth * 2) / 2, -borderWidth - 64, windowWidth + borderWidth * 2, Game1.uiViewport.Height + borderWidth * 2 + 64, false)
         {
             currentSort = ModEntry.Config.CurrentSort;
             instance = this;

--- a/AllChestsMenu/StorageMenu.cs
+++ b/AllChestsMenu/StorageMenu.cs
@@ -24,7 +24,7 @@ namespace AllChestsMenu
     public class StorageMenu : IClickableMenu
     {
         public static int scrolled;
-        public static int windowWidth = 64 * 25;
+        public static int windowWidth = 64 * 26;
         public static StorageMenu instance;
         
         public int xSpace = 64;
@@ -88,7 +88,7 @@ namespace AllChestsMenu
         public string fridgeString;
         private string sortString;
 
-        public StorageMenu() : base(Game1.uiViewport.Width / 2 - (windowWidth + borderWidth * 2) / 2, -borderWidth - 64, 64 * 26 + 4 + borderWidth * 2, Game1.uiViewport.Height + borderWidth * 2 + 64, false)
+		public StorageMenu() : base(Game1.uiViewport.Width / 2 - (windowWidth + borderWidth * 2) / 2, -borderWidth - 64, windowWidth + borderWidth * 2, Game1.uiViewport.Height + borderWidth * 2 + 64, false)
         {
             currentSort = ModEntry.Config.CurrentSort;
             instance = this;
@@ -141,7 +141,7 @@ namespace AllChestsMenu
             locationText = new TextBox(Game1.content.Load<Texture2D>("LooseSprites\\textBox"), null, Game1.smallFont, Game1.textColor)
             {
                 X = xPositionOnScreen + borderWidth,
-                Width = (width - playerInventoryMenu.width) / 2 - borderWidth * 2 - 64,
+                Width = (width - playerInventoryMenu.width) / 2 - borderWidth * 2 - 32,
                 Y = cutoff + borderWidth + 32,
                 Text = whichLocation
             };

--- a/AllChestsMenu/StorageMenu.cs
+++ b/AllChestsMenu/StorageMenu.cs
@@ -944,7 +944,7 @@ namespace AllChestsMenu
 
         public void SwapMenus(int idx1, int idx2)
         {
-            if (ModEntry.SHelper.Input.IsDown(SButton.LeftShift))
+            if (ModEntry.SHelper.Input.IsDown(ModEntry.Config.ModKey))
             {
                 SwapContents(allStorageList[idx1].chest.items, allStorageList[idx2].chest.items);
                 heldMenu = -1;

--- a/AllChestsMenu/StorageMenu.cs
+++ b/AllChestsMenu/StorageMenu.cs
@@ -269,7 +269,7 @@ namespace AllChestsMenu
                             chestName = "";
                         }
 
-                        allStorageList.Add(new StorageData() { chest = chest, name = chestName, location = l.Name, tile = new Vector2(-1, -1), label = key, index = allStorageList.Count });
+                        allStorageList.Add(new StorageData() { chest = chest, name = chestName, location = l.Name, tile = new Vector2(kvp.Key.X, kvp.Key.Y), label = key, index = allStorageList.Count });
 
                     }
                 }

--- a/AllChestsMenu/StorageMenu.cs
+++ b/AllChestsMenu/StorageMenu.cs
@@ -415,7 +415,7 @@ namespace AllChestsMenu
                 {
                     break;
                 }
-                if (i == heldMenu)
+                if (i == heldMenu - (storageList[i].index - i))
                     continue;
                 SpriteText.drawString(b, storage.label, storage.menu.xPositionOnScreen, storage.menu.yPositionOnScreen - 48);
                 if (!storage.collapsed)

--- a/AllChestsMenu/i18n/default.json
+++ b/AllChestsMenu/i18n/default.json
@@ -15,5 +15,17 @@
   "sort-CA": "Capacity (Asc)",
   "sort-CD": "Capacity (Desc)",
   "sort-IA": "Items (Asc)",
-  "sort-ID": "Items (Desc)"
+  "sort-ID": "Items (Desc)",
+
+  // GMCM
+  "GMCM_Option_ModEnabled_Name": "Mod Enabled",
+  "GMCM_Option_LimitToCurrentLocation_Name": "Current Loc Only",
+  "GMCM_Option_MenuKey_Name": "Menu Key",
+  "GMCM_Option_ModToOpen_Name": "Req. Mod Key To Open",
+  "GMCM_Option_ModKey_Name": "Mod Key",
+  "GMCM_Option_ModKey_Tooltip": "Hold down to open menu and to transfer contents instead of swapping menus",
+  "GMCM_Option_ModKey2_Name": "Mod Key 2",
+  "GMCM_Option_ModKey2_Tooltip": "Hold down to transfer only same items when transfering all",
+  "GMCM_Option_SwitchButton_Name": "Switch Button",
+  "GMCM_Option_SwitchButton_Tooltip": "For controllers to switch between upper and lower interfaces"
 }

--- a/AllChestsMenu/i18n/default.json
+++ b/AllChestsMenu/i18n/default.json
@@ -8,7 +8,6 @@
   "rename": "Rename",
   "target": "Target",
   "sort": "Sort By",
-  "store-similar": "Store Similar",
   "sort-LA": "Location (Asc)",
   "sort-LD": "Location (Desc)",
   "sort-NA": "Name (Asc)",

--- a/AllChestsMenu/i18n/fr.json
+++ b/AllChestsMenu/i18n/fr.json
@@ -1,0 +1,31 @@
+﻿{
+  "filter": "Filtre",
+  "name": "Nom",
+  "fridge": "Réfrigérateur",
+  "open": "Ouvrir",
+  "put": "Déposer",
+  "take": "Prendre",
+  "rename": "Renommer",
+  "target": "Cibler",
+  "sort": "Trier par",
+  "sort-LA": "Emplacement (Asc)",
+  "sort-LD": "Emplacement (Desc)",
+  "sort-NA": "Nom (Asc)",
+  "sort-ND": "Nom (Desc)",
+  "sort-CA": "Capacité (Asc)",
+  "sort-CD": "Capacité (Desc)",
+  "sort-IA": "Objets (Asc)",
+  "sort-ID": "Objets (Desc)",
+
+  // GMCM
+  "GMCM_Option_ModEnabled_Name": "Activer le Mod",
+  "GMCM_Option_LimitToCurrentLocation_Name": "Emplacement actuel uniquement",
+  "GMCM_Option_MenuKey_Name": "Touche pour ouvrir le menu",
+  "GMCM_Option_ModToOpen_Name": "Nécessite la touche secondaire",
+  "GMCM_Option_ModKey_Name": "Touche secondaire",
+  "GMCM_Option_ModKey_Tooltip": "Maintenez enfoncé pour ouvrir le menu et pour transférer le contenu au lieu d'intervertir les menus.",
+  "GMCM_Option_ModKey2_Name": "Touche tertiaire",
+  "GMCM_Option_ModKey2_Tooltip": "Maintenez enfoncé pour transférer uniquement les objets similaires lorsque les objets sont tous pris ou déposés.",
+  "GMCM_Option_SwitchButton_Name": "Touche de commutation",
+  "GMCM_Option_SwitchButton_Tooltip": "Touche permettant aux manettes de basculer entre les interfaces supérieure et inférieure."
+}


### PR DESCRIPTION
### Fixes:
* (03dfa394c06b609b65db6a2b03605da231f58e4b) When a farmhouse chest is renamed, its label becomes that of a fridge.
The addition of chests to `allStorageList` has been fixed so that the tile property contains the coordinates of the chest, preventing it from being considered as a fridge.
* (e98fc821b332779704ebc36879b2d652f4f5d0eb) When a chest is renamed with an empty name, its label becomes that of a renamed chest.
A condition has been added to check whether the new chest name is empty, and to assign it the label of a non-renamed chest in that case.
* (3a27fb45617813093437c3697fd5286236a892c3) The menu is not perfectly centered horizontally.
The width has been adjusted to fix this.
* (03d038c630be0008a2c5069f099ba82b4eb598e3) In the GMCM menu, Mod Key 2 sets the value of `Config.SwitchButton` and Switch Button sets the value of `Config.ModKey2`.
The GMCM menu has been modified to fix this.
* (de783e2d469e91c7e70f7621747888237c2a6899) The default Mod Key value is always used, even if the key has been modified.
The condition in the SwapMenus function has been modified to use the Mod Key value instead of LeftShift.
* (f35088b6491d6ccaa31f3d54a243fc83fdc6fd29) When a menu is held and a filter is activated hiding chests positioned before the held chest in the list. It is not the menu of the held chest that is not displayed, but that of another chest.
The chest non-display condition has been modified to fix this.

### Improvements:
* (6e5f5a55fd5c4f79b1f2acab061b4d6ae9c797bc) The **bigSelect** sound is played when opening the menu.

### Features:
* (1fcaa33b95cf47327a633be4de02b768c38b036f) Translation support has been added for the GMCM menu.
* (f2f496c76106f8f5cfe5e0f5e81ec177246b2d20) French translation has been added.