### PR TITLE
[BatForm] Various fixes, improvements and features

### DIFF
--- a/BatForm/CodePatches.cs
+++ b/BatForm/CodePatches.cs
@@ -79,5 +79,25 @@ namespace BatForm
                 return false;
             }
         }
+        [HarmonyPatch(typeof(Game1), nameof(Game1.pressActionButton))]
+        public class Game1_pressActionButton_Patch
+        {
+            public static bool Prefix()
+            {
+                if (!Config.ModEnabled || Config.ActionsEnabled || BatFormStatus(Game1.player) == BatForm.Inactive)
+                    return true;
+                return false;
+            }
+        }
+        [HarmonyPatch(typeof(Game1), nameof(Game1.pressUseToolButton))]
+        public class Game1_pressUseToolButton_Patch
+        {
+            public static bool Prefix()
+            {
+                if (!Config.ModEnabled || Config.ActionsEnabled || BatFormStatus(Game1.player) == BatForm.Inactive)
+                    return true;
+                return false;
+            }
+        }
     }
 }

--- a/BatForm/Methods.cs
+++ b/BatForm/Methods.cs
@@ -55,5 +55,46 @@ namespace BatForm
             return Enum.Parse<BatForm>(str);
 
         }
+
+        private static void EnforceMapBounds()
+        {
+            if (Game1.isWarping || Game1.currentLocation == null)
+                return;
+
+            xTile.Dimensions.Location tileLocation = Game1.player.nextPositionTile();
+            int nextTilePositionX = tileLocation.X;
+            int nextTilePositionY = tileLocation.Y;
+            xTile.Dimensions.Location location = Game1.player.nextPositionPoint();
+            int nextPositionX = location.X;
+            int nextPositionY = location.Y;
+
+            if (nextTilePositionX == Game1.player.getTileX() && nextTilePositionY == Game1.player.getTileY())
+            {
+                if (nextPositionX < 0)
+                    nextTilePositionX--;
+                if (nextPositionY < 0)
+                    nextTilePositionY--;
+            }
+
+            foreach (Warp warp in Game1.currentLocation.warps)
+            {
+                if (warp.X == nextTilePositionX && warp.Y == nextTilePositionY)
+                    return;
+            }
+
+            const int offsetX = 0;
+            const int offsetY = Game1.tileSize / 4;
+            int maxX = Game1.currentLocation.map.DisplaySize.Width - Game1.tileSize;
+            int maxY = Game1.currentLocation.map.DisplaySize.Height - Game1.tileSize + offsetY;
+
+            if (Game1.player.position.X < offsetX)
+                Game1.player.position.X = offsetX;
+            if (Game1.player.position.X > maxX)
+                Game1.player.position.X = maxX;
+            if (Game1.player.position.Y < offsetY)
+                Game1.player.position.Y = offsetY;
+            if (Game1.player.position.Y > maxY)
+                Game1.player.position.Y = maxY;
+        }
     }
 }

--- a/BatForm/Methods.cs
+++ b/BatForm/Methods.cs
@@ -40,6 +40,8 @@ namespace BatForm
         {
             Game1.player.modData.Remove(batFormKey);
             height.Value = 0;
+            Game1.forceSnapOnNextViewportUpdate = true;
+            Game1.game1.refreshWindowSettings();
             if(Game1.player is not null)
             {
                 Game1.player.ignoreCollisions = false;

--- a/BatForm/Methods.cs
+++ b/BatForm/Methods.cs
@@ -40,6 +40,7 @@ namespace BatForm
         {
             Game1.player.modData.Remove(batFormKey);
             height.Value = 0;
+            heightViewportLimit.Value = maxHeight;
             Game1.forceSnapOnNextViewportUpdate = true;
             Game1.game1.refreshWindowSettings();
             if(Game1.player is not null)

--- a/BatForm/ModConfig.cs
+++ b/BatForm/ModConfig.cs
@@ -10,6 +10,7 @@ namespace BatForm
         public bool NightOnly { get; set; } = false;
         public bool OutdoorsOnly { get; set; } = true;
         public KeybindList TransformKey { get; set; } = new KeybindList(SButton.NumPad5);
+        public bool ActionsEnabled { get; set; } = false;
         public string TransformSound { get; set; } = "cowboy_explosion";
         public int MoveSpeed { get; set; } = 10;
         public int StaminaUse { get; set; } = 0;

--- a/BatForm/ModEntry.cs
+++ b/BatForm/ModEntry.cs
@@ -144,9 +144,14 @@ namespace BatForm
             }
             var status = BatFormStatus(Game1.player);
             if (status != BatForm.Inactive)
+            {
                 Game1.player.temporarilyInvincible = true;
+                EnforceMapBounds();
+            }
             else
+            {
                 return;
+            }
             if (status != BatForm.Active)
             {
                 if (status == BatForm.SwitchingFrom)

--- a/BatForm/ModEntry.cs
+++ b/BatForm/ModEntry.cs
@@ -211,57 +211,56 @@ namespace BatForm
 
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Mod Enabled",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModEnabled_Name"),
                 getValue: () => Config.ModEnabled,
                 setValue: value => Config.ModEnabled = value
             );
             
-
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Night Only",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_NightOnly_Name"),
                 getValue: () => Config.NightOnly,
                 setValue: value => Config.NightOnly = value
             );
             
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Outdoors Only",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_OutdoorsOnly_Name"),
                 getValue: () => Config.OutdoorsOnly,
                 setValue: value => Config.OutdoorsOnly = value
             );
             
             configMenu.AddKeybindList(
                 mod: ModManifest,
-                name: () => "Transform Key",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_TransformKey_Name"),
                 getValue: () => Config.TransformKey,
                 setValue: value => Config.TransformKey = value
             );
 
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Actions Enabled",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ActionsEnabled_Name"),
                 getValue: () => Config.ActionsEnabled,
                 setValue: value => Config.ActionsEnabled = value
             );
             
             configMenu.AddNumberOption(
                 mod: ModManifest,
-                name: () => "Move Speed",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_MoveSpeed_Name"),
                 getValue: () => Config.MoveSpeed,
                 setValue: value => Config.MoveSpeed = value
             );
             
             configMenu.AddNumberOption(
                 mod: ModManifest,
-                name: () => "Stamina Use",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_StaminaUse_Name"),
                 getValue: () => Config.StaminaUse,
                 setValue: value => Config.StaminaUse = value
             );
 
             configMenu.AddTextOption(
                 mod: ModManifest,
-                name: () => "Transform Sound",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_TransformSound_Name"),
                 getValue: () => Config.TransformSound,
                 setValue: value => Config.TransformSound = value
             );

--- a/BatForm/ModEntry.cs
+++ b/BatForm/ModEntry.cs
@@ -32,6 +32,7 @@ namespace BatForm
 
         public static PerScreen<ICue> batSound = new();
         public static PerScreen<int> height = new();
+        public static PerScreen<int> heightViewportLimit = new();
         public static PerScreen<AnimatedSprite> batSprite = new();
 
         public enum BatForm
@@ -86,6 +87,9 @@ namespace BatForm
         {
             if (!Config.ModEnabled || e.Player != Game1.player || BatFormStatus(e.Player) == BatForm.Inactive)
                 return;
+            heightViewportLimit.Value = maxHeight;
+            Game1.forceSnapOnNextViewportUpdate = true;
+            Game1.game1.refreshWindowSettings();
             if(Config.OutdoorsOnly && !e.NewLocation.IsOutdoors)
             {
                 ResetBat();
@@ -160,6 +164,7 @@ namespace BatForm
                     if (height.Value == 0)
                     {
                         PlayTransform();
+                        heightViewportLimit.Value = maxHeight;
                         Game1.player.ignoreCollisions = false;
                         Game1.player.modData[batFormKey] = BatForm.Inactive + "";
                     }

--- a/BatForm/ModEntry.cs
+++ b/BatForm/ModEntry.cs
@@ -232,6 +232,13 @@ namespace BatForm
                 getValue: () => Config.TransformKey,
                 setValue: value => Config.TransformKey = value
             );
+
+            configMenu.AddBoolOption(
+                mod: ModManifest,
+                name: () => "Actions Enabled",
+                getValue: () => Config.ActionsEnabled,
+                setValue: value => Config.ActionsEnabled = value
+            );
             
             configMenu.AddNumberOption(
                 mod: ModManifest,

--- a/BatForm/i18n/default.json
+++ b/BatForm/i18n/default.json
@@ -1,0 +1,11 @@
+{
+  // GMCM
+  "GMCM_Option_ModEnabled_Name": "Mod Enabled",
+  "GMCM_Option_NightOnly_Name": "Night Only",
+  "GMCM_Option_OutdoorsOnly_Name": "Outdoors Only",
+  "GMCM_Option_TransformKey_Name": "Transform Key",
+  "GMCM_Option_ActionsEnabled_Name": "Actions Enabled",
+  "GMCM_Option_MoveSpeed_Name": "Move Speed",
+  "GMCM_Option_StaminaUse_Name": "Stamina Use",
+  "GMCM_Option_TransformSound_Name": "Transform Sound"
+}

--- a/BatForm/i18n/fr.json
+++ b/BatForm/i18n/fr.json
@@ -1,0 +1,11 @@
+{
+  // GMCM
+  "GMCM_Option_ModEnabled_Name": "Activer le Mod",
+  "GMCM_Option_NightOnly_Name": "Uniquement la nuit",
+  "GMCM_Option_OutdoorsOnly_Name": "Uniquement en extérieur",
+  "GMCM_Option_TransformKey_Name": "Touche de transformation",
+  "GMCM_Option_ActionsEnabled_Name": "Actions autorisées",
+  "GMCM_Option_MoveSpeed_Name": "Vitesse de déplacement",
+  "GMCM_Option_StaminaUse_Name": "Consommation d'endurance",
+  "GMCM_Option_TransformSound_Name": "Son de transformation"
+}


### PR DESCRIPTION
### Fixes:
* (791e0b7fc227afab1b64a6a3af25ae25978ca819) When the player warps to a map in bat form and a cutscene is triggered, the viewport may not be correctly positioned.
A viewport reset has been added to the **ResetBat** function to fix this.
* (c33f756a6c427a369627666012df2a76ef9ff75d) It's possible to do all the basic actions of the game in bat form, which looks wrong.
A harmony patch has been added to prevent the use of the ActionButton and UseToolButton in bat form. An option has also been added to the GMCM menu to toggle this.
### Improvements:
* (40c0fd457a42159408a9113c5916137ffb488090) The **EnforceMapBounds** method has been added to prevent the player from flying off the map.
* (2748f4189443fc69b282f65810b0cb336d977b7c) The zoom-out feature has been improved by limiting it to the map size.
### Features:
* (45aa62bbedcc0073edc6acc82dd6789823027acc) Translation support has been added for the GMCM menu.
* (fe0d4ca1d0e187fdfc7a8a768f8f3d3acf73bc6e) French translation has been added.