### PR TITLE
[BetterLightningRods] Various fixes and features

### DIFF
--- a/BetterLightningRods/CodePatches.cs
+++ b/BetterLightningRods/CodePatches.cs
@@ -29,11 +29,12 @@ namespace BetterLightningRods
                     codes[i + 1] = new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(ModEntry), nameof(ModEntry.GetRodsToCheck)));
                     rodsFound = true;
                 }
-                else if (!chanceFound && codes[i].opcode == OpCodes.Ldc_R8 && (double)codes[i].operand == 0.125)
+                else if (!chanceFound && i < codes.Count - 12 && codes[i].opcode == OpCodes.Ldc_R8 && (double)codes[i].operand == 0.125 && codes[i + 1].opcode == OpCodes.Call && codes[i + 2].opcode == OpCodes.Callvirt && codes[i + 3].opcode == OpCodes.Ldnull && codes[i + 4].opcode == OpCodes.Callvirt && codes[i + 5].opcode == OpCodes.Add && codes[i + 6].opcode == OpCodes.Call && codes[i + 7].opcode == OpCodes.Callvirt && codes[i + 8].opcode == OpCodes.Ldnull && codes[i + 9].opcode == OpCodes.Callvirt && codes[i + 10].opcode == OpCodes.Ldc_R8 && (double)codes[i + 10].operand == 100.0 && codes[i + 11].opcode == OpCodes.Div && codes[i + 12].opcode == OpCodes.Add)
                 {
                     SMonitor.Log($"Overriding lightning chance");
                     codes[i].opcode = OpCodes.Call;
                     codes[i].operand = AccessTools.Method(typeof(ModEntry), nameof(ModEntry.GetLightningChance));
+                    codes.RemoveRange(i + 1, 12);
                     chanceFound = true;
                 }
                 else if (!shuffleFound && Config.UniqueCheck && i < codes.Count - 2 && codes[i + 2].opcode == OpCodes.Ble && codes[i + 1].opcode == OpCodes.Ldc_I4_0 && codes[i].opcode == OpCodes.Callvirt && codes[i - 1].opcode == OpCodes.Ldloc_3)

--- a/BetterLightningRods/CodePatches.cs
+++ b/BetterLightningRods/CodePatches.cs
@@ -68,5 +68,10 @@ namespace BetterLightningRods
         {
             return Config.EnableMod ? Config.RodsToCheck : 2;
         }
+
+        private static bool Farm_doLightningStrike_Patch()
+        {
+            return !(Config.EnableMod && Config.Astraphobia);
+        }
     }
 }

--- a/BetterLightningRods/ModConfig.cs
+++ b/BetterLightningRods/ModConfig.cs
@@ -11,6 +11,6 @@ namespace BetterLightningRods
         public int RodsToCheck { get; set; } = 2;
         public float LightningChance { get; set; } = 13f;
         public SButton LightningButton { get; set; } = SButton.F15;
-
+        public bool Astraphobia { get; set; } = false;
     }
 }

--- a/BetterLightningRods/ModEntry.cs
+++ b/BetterLightningRods/ModEntry.cs
@@ -72,27 +72,27 @@ namespace BetterLightningRods
 
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Mod Enabled?",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_ModEnabled_Name"),
                 getValue: () => Config.EnableMod,
                 setValue: value => Config.EnableMod = value
             );
             configMenu.AddBoolOption(
                 mod: ModManifest,
-                name: () => "Unique Check?",
-                tooltip: () => "Don't check the same rod twice per strike.",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_UniqueCheck_Name"),
+                tooltip: () => ModEntry.SHelper.Translation.Get("GMCM_Option_UniqueCheck_Tooltip"),
                 getValue: () => Config.UniqueCheck,
                 setValue: value => Config.UniqueCheck = value
             );
             configMenu.AddNumberOption(
                 mod: ModManifest,
-                name: () => "Rods To Check",
-                tooltip: () => "Each time lightning strikes, check this many rods to see if they can receive the charge.",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_RodsToCheck_Name"),
+                tooltip: () => ModEntry.SHelper.Translation.Get("GMCM_Option_RodsToCheck_Tooltip"),
                 getValue: () => Config.RodsToCheck,
                 setValue: value => Config.RodsToCheck = value
             );
             configMenu.AddNumberOption(
                 mod: ModManifest,
-                name: () => "Base Lightning Chance",
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_LightningChance_Name"),
                 getValue: () => (int)Config.LightningChance,
                 setValue: value => Config.LightningChance = value,
                 min: 0,

--- a/BetterLightningRods/ModEntry.cs
+++ b/BetterLightningRods/ModEntry.cs
@@ -43,7 +43,10 @@ namespace BetterLightningRods
                original: AccessTools.Method(typeof(Utility), nameof(Utility.performLightningUpdate)),
                transpiler: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Utility_performLightningUpdate_Transpiler))
             );
-
+            harmony.Patch(
+               original: AccessTools.Method(typeof(Farm), "doLightningStrike"),
+               prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Farm_doLightningStrike_Patch))
+            );
         }
 
         private void Input_ButtonPressed(object sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)
@@ -98,6 +101,13 @@ namespace BetterLightningRods
                 setValue: value => Config.LightningChance = value,
                 min: 0,
                 max: 100
+            );
+            configMenu.AddBoolOption(
+                mod: ModManifest,
+                name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_Astraphobia_Name"),
+                tooltip: () => ModEntry.SHelper.Translation.Get("GMCM_Option_Astraphobia_Tooltip"),
+                getValue: () => Config.Astraphobia,
+                setValue: value => Config.Astraphobia = value
             );
         }
         private static int GetLightningRod(List<Vector2> rods, int index)

--- a/BetterLightningRods/ModEntry.cs
+++ b/BetterLightningRods/ModEntry.cs
@@ -93,6 +93,7 @@ namespace BetterLightningRods
             configMenu.AddNumberOption(
                 mod: ModManifest,
                 name: () => ModEntry.SHelper.Translation.Get("GMCM_Option_LightningChance_Name"),
+                tooltip: () => ModEntry.SHelper.Translation.Get("GMCM_Option_LightningChance_Tooltip"),
                 getValue: () => (int)Config.LightningChance,
                 setValue: value => Config.LightningChance = value,
                 min: 0,

--- a/BetterLightningRods/i18n/default.json
+++ b/BetterLightningRods/i18n/default.json
@@ -6,5 +6,7 @@
   "GMCM_Option_RodsToCheck_Name": "Rods To Check",
   "GMCM_Option_RodsToCheck_Tooltip": "Each time lightning strikes, check this many rods to see if they can receive the charge.",
   "GMCM_Option_LightningChance_Name": "Lightning Chance",
-  "GMCM_Option_LightningChance_Tooltip": "Percent chance for lightning to strike, every ten minutes."
+  "GMCM_Option_LightningChance_Tooltip": "Percent chance for lightning to strike, every ten minutes.",
+  "GMCM_Option_Astraphobia_Name": "Astraphobia",
+  "GMCM_Option_Astraphobia_Tooltip": "Disable storm-related audio and visual effects."
 }

--- a/BetterLightningRods/i18n/default.json
+++ b/BetterLightningRods/i18n/default.json
@@ -5,5 +5,6 @@
   "GMCM_Option_UniqueCheck_Tooltip": "Don't check the same rod twice per strike.",
   "GMCM_Option_RodsToCheck_Name": "Rods To Check",
   "GMCM_Option_RodsToCheck_Tooltip": "Each time lightning strikes, check this many rods to see if they can receive the charge.",
-  "GMCM_Option_LightningChance_Name": "Lightning Chance"
+  "GMCM_Option_LightningChance_Name": "Lightning Chance",
+  "GMCM_Option_LightningChance_Tooltip": "Percent chance for lightning to strike, every ten minutes."
 }

--- a/BetterLightningRods/i18n/default.json
+++ b/BetterLightningRods/i18n/default.json
@@ -1,0 +1,9 @@
+{
+  // GMCM
+  "GMCM_Option_ModEnabled_Name": "Mod Enabled",
+  "GMCM_Option_UniqueCheck_Name": "Unique Check?",
+  "GMCM_Option_UniqueCheck_Tooltip": "Don't check the same rod twice per strike.",
+  "GMCM_Option_RodsToCheck_Name": "Rods To Check",
+  "GMCM_Option_RodsToCheck_Tooltip": "Each time lightning strikes, check this many rods to see if they can receive the charge.",
+  "GMCM_Option_LightningChance_Name": "Lightning Chance"
+}

--- a/BetterLightningRods/i18n/fr.json
+++ b/BetterLightningRods/i18n/fr.json
@@ -1,0 +1,10 @@
+{
+  // GMCM
+  "GMCM_Option_ModEnabled_Name": "Activer le Mod",
+  "GMCM_Option_UniqueCheck_Name": "Vérification unique",
+  "GMCM_Option_UniqueCheck_Tooltip": "Ne pas vérifier le même paratonnerre deux fois par frappe.",
+  "GMCM_Option_RodsToCheck_Name": "Paratonnerres à vérifier",
+  "GMCM_Option_RodsToCheck_Tooltip": "À chaque fois qu'un éclair frappe, vérifiez ce nombre de paratonnerres pour voir s'ils peuvent recevoir la charge.",
+  "GMCM_Option_LightningChance_Name": "Chance d'éclair (en %)",
+  "GMCM_Option_LightningChance_Tooltip": "Pourcentage de chance qu'un éclair frappe, toutes les dix minutes."
+}

--- a/BetterLightningRods/i18n/fr.json
+++ b/BetterLightningRods/i18n/fr.json
@@ -6,5 +6,7 @@
   "GMCM_Option_RodsToCheck_Name": "Paratonnerres à vérifier",
   "GMCM_Option_RodsToCheck_Tooltip": "À chaque fois qu'un éclair frappe, vérifiez ce nombre de paratonnerres pour voir s'ils peuvent recevoir la charge.",
   "GMCM_Option_LightningChance_Name": "Chance d'éclair (en %)",
-  "GMCM_Option_LightningChance_Tooltip": "Pourcentage de chance qu'un éclair frappe, toutes les dix minutes."
+  "GMCM_Option_LightningChance_Tooltip": "Pourcentage de chance qu'un éclair frappe, toutes les dix minutes.",
+  "GMCM_Option_Astraphobia_Name": "Astraphobie",
+  "GMCM_Option_Astraphobia_Tooltip": "Désactive les effets audio et visuels liés aux orages."
 }


### PR DESCRIPTION
### Fixes:
* (a6e0da3b7445c8b5801be69efa5771f7324ae839) The harmony transpilation replaces only the basic lightning chance, i.e. `0.125` in the condition `random.NextDouble() < 0.125 + Game1.player.team.AverageDailyLuck() + Game1.player.team.AverageLuckLevel() / 100.0` of the **performLightningUpdate** function. This means that setting the lightning chance to `0` doesn't totally prevent lightning from striking, as the luck of the day and the luck level can be enough to cause a lightning strike.
The transpilation has been modified to remove the day chance and luck level from the calculation. The condition is now: `random.NextDouble() < getLigtningChance()`.
### Features:
* (97132da1dc691504096f921dd7bfa4af9ba1a76c) Translation support has been added for the GMCM menu.
* (aa87763ee4d5e7641a6690edb71ef1ea7b24b947) French translation has been added.
* (e531c23e75742807b42ff2ece0d6bbfd53f24be5) Astraphobia option has been added to disable storm-related sound and visual effects.