### PR TITLE
[ContentPatcherEditor] Fix title menu button and add French Translation

### DIFF
--- a/ContentPatcherEditor/ModEntry.cs
+++ b/ContentPatcherEditor/ModEntry.cs
@@ -42,7 +42,7 @@ namespace ContentPatcherEditor
 
         private void Input_ButtonPressed(object sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)
         {
-            if(Config.ModEnabled && Config.ShowButton && e.Button == SButton.MouseLeft && Game1.activeClickableMenu is TitleMenu && TitleMenu.subMenu is not ContentPatcherMenu && TitleMenu.subMenu is not ContentPackMenu)
+            if(Config.ModEnabled && Config.ShowButton && e.Button == SButton.MouseLeft && Game1.activeClickableMenu is TitleMenu && TitleMenu.subMenu is null)
             {
                 var rect = new Rectangle(42, Game1.viewport.Height - 192, 64, 64);
                 if (rect.Contains(Game1.getMousePosition()))
@@ -57,7 +57,7 @@ namespace ContentPatcherEditor
 
         private void Display_RenderedActiveMenu(object sender, StardewModdingAPI.Events.RenderedActiveMenuEventArgs e)
         {
-            if (Config.ModEnabled && Config.ShowButton && Game1.activeClickableMenu is TitleMenu && TitleMenu.subMenu is not ContentPatcherMenu && TitleMenu.subMenu is not ContentPackMenu)
+            if (Config.ModEnabled && Config.ShowButton && Game1.activeClickableMenu is TitleMenu && TitleMenu.subMenu is null)
             {
                 var rect = new Rectangle(42, Game1.viewport.Height - 192, 64, 64);
                 e.SpriteBatch.Draw(Game1.mouseCursors, rect, new Rectangle(330, 373, 16, 16), rect.Contains(Game1.getMousePosition()) ? Color.White : Color.White * 0.5f);

--- a/ContentPatcherEditor/i18n/fr.json
+++ b/ContentPatcherEditor/i18n/fr.json
@@ -1,0 +1,23 @@
+{
+  "GMCM_Option_ModEnabled_Name": "Activer le Mod",
+  "GMCM_Option_ShowButton_Name": "Bouton sur l'écran-titre",
+  "GMCM_Option_Backup_Name": "Fichiers de sauvegarde",
+  "GMCM_Option_MenuButton_Name": "Touches pour ouvrir le menu",
+  "GMCM_Option_OpenModsFolderAfterZip_Name": "Ouvrir le dossier après la compression",
+  "content-packs": "Packs de contenu CP",
+  "manifest": "Manifeste",
+  "changes": "Changements",
+  "config": "Configuration",
+  "add": "Ajouter",
+  "back": "Retour à la liste des packs",
+  "up": "Haut",
+  "down": "Bas",
+  "remove": "Supprimer",
+  "allow-blank": "Autoriser les valeurs vides",
+  "allow-multiple": "Autoriser les valeurs multiples",
+  "folder": "Ouvrir le dossier",
+  "zip": "Créer un fichier zip",
+  "save": "Sauvegarder le pack de contenu",
+  "reload": "Recharger le pack de contenu",
+  "revert": "Annuler les modifications du pack de contenu"
+}


### PR DESCRIPTION
### Fixes:
* (343583f5d8ef9f2aded1147c439bef4c3b193357) The mod button from the title menu remains displayed in several submenus (game creation, game loading, language selection, credit, GMCM...). Using the button from these submenus causes unexpected behavior.
The conditions for displaying and using this button have been modified so that it is only available in the title menu when there is no sub-menu (`Game1.activeClickableMenu is TitleMenu && TitleMenu.subMenu is null`).
### Features:
* (38c1f98380895a0dcc5d8e7978906aec4cd8bd1a) Added French translation.