### PR TITLE
[CropWateringBubbles] Fix dwoop sound and add French translation

### DIFF
--- a/CropWateringBubbles/ModEntry.cs
+++ b/CropWateringBubbles/ModEntry.cs
@@ -84,7 +84,7 @@ namespace CropWateringBubbles
 
         private void Input_ButtonsChanged(object sender, ButtonsChangedEventArgs e)
         {
-            if (Config.ModEnabled && Context.CanPlayerMove && !isEmoting && Config.RequireKeyPress && Config.PressKeys.JustPressed())
+            if (Config.ModEnabled && Context.CanPlayerMove && !isEmoting && Config.RequireKeyPress && Config.PressKeys.JustPressed() && (!Config.OnlyWhenWatering || Game1.player.CurrentTool is WateringCan))
             {
                 isEmoting = true;
                 Game1.playSound("dwoop");

--- a/CropWateringBubbles/i18n/fr.json
+++ b/CropWateringBubbles/i18n/fr.json
@@ -1,0 +1,10 @@
+{
+  "GMCM_Option_ModEnabled_Name": "Activer le Mod",
+  "GMCM_Option_OpacityPercent_Name": "Opacité (en %)",
+  "GMCM_Option_SizePercent_Name": "Taille (en %)",
+  "GMCM_Option_PressKeys_Name": "Touches d'activation",
+  "GMCM_Option_RepeatInterval_Name": "Intervalle de répétition",
+  "GMCM_Option_RequireKeyPress_Name": "Nécessite les touches d'activation",
+  "GMCM_Option_IncludeGiantable_Name": "Afficher pour les cultures géantes",
+  "GMCM_Option_OnlyWhenWatering_Name": "Uniquement lors de l'arrosage"
+}


### PR DESCRIPTION
### Fixes:
* (21aadcdff879332b222d4f24f287e99772033bc2) If the mod is configured with key press and only when watering enabled, the **dwoop** sound is played even if the player is not holding a watering can.
The condition for playing the sound has been modified to fix this.
### Features:
* (b7689f5b8ebd3b55c5c068daf36208c1b9bfd816) French translation has been added.