### PR TITLE
[MapTeleport] Add alt id for hidden locations, hooks for RSV, East Scarp, and additional options for SVE

### DIFF
--- a/MapTeleport/CodePatches.cs
+++ b/MapTeleport/CodePatches.cs
@@ -2,46 +2,99 @@
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Menus;
+using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace MapTeleport
 {
     public partial class ModEntry
     {
- 
+        protected static CoordinatesList addedCoordinates;
+        public static bool CheckClickableComponents(List<ClickableComponent> components, int topX, int topY, int x, int y)
+        {
+            if (!Config.ModEnabled)
+                return false;
+            if (addedCoordinates == null)
+            {
+                addedCoordinates = SHelper.Data.ReadJsonFile<CoordinatesList>("coordinates.json");
+                if (addedCoordinates == null) addedCoordinates = new CoordinatesList();
+            }
+            var coordinates = SHelper.GameContent.Load<CoordinatesList>(dictPath);
+            bool added = false;
+            bool found = false;
+            // Sort boundries so that the function will warp to the smallest overlapping area
+            components.Sort(delegate (ClickableComponent a, ClickableComponent b)
+            {
+                return (a.bounds.Height * a.bounds.Width).CompareTo(b.bounds.Height * b.bounds.Width);
+            });
+            foreach (ClickableComponent c in components)
+            { 
+                // Offset so that this works for any screen size
+                string altId = $"{c.bounds.X - topX}.{c.bounds.Y - topY}";
+                Predicate<Coordinates> findMatch = (o) => o.id == c.myID || (c.myID == ClickableComponent.ID_ignore && o.altId == altId);
+                Coordinates co = coordinates.coordinates.Find(findMatch);
+                if (co == null)
+                {
+                    co = addedCoordinates.coordinates.Find(findMatch);
+                    if (co == null)
+                    {
+                        if (c.myID == ClickableComponent.ID_ignore)
+                        {
+                            addedCoordinates.Add(new Coordinates() { name = c.name, altId = altId, enabled = false });
+                        }
+                        else
+                        {
+                            addedCoordinates.Add(new Coordinates() { name = c.name, id = c.myID, enabled = false });
+                        }
+                        SMonitor.Log($"Added: {{ \"name\":\"{c.name}\", \"id\":{c.myID}, \"altId\":\"{altId}\" }}", LogLevel.Trace);
+                        added = true;
+                    }
+                    // else check if the coordinate is enabled
+                }
+
+                if (c.containsPoint(x, y) && co.enabled)
+                {
+                    SMonitor.Log($"Teleporting to {c.name} ({(co.altId != null ? co.altId : co.id)}), {co.mapName}, {co.x},{co.y}", LogLevel.Debug);
+                    Game1.activeClickableMenu?.exitThisMenu(true);
+                    Game1.warpFarmer(co.mapName, co.x, co.y, false);
+                    found = true;
+                    break;
+                }
+            }
+            if (added)
+            {
+                SHelper.Data.WriteJsonFile("coordinates.json", addedCoordinates);
+            }
+            return found;
+
+        }
+
         [HarmonyPatch(typeof(MapPage), nameof(MapPage.receiveLeftClick))]
         public class MapPage_receiveLeftClick_Patch
         {
             public static bool Prefix(MapPage __instance, int x, int y)
             {
-                if (!Config.ModEnabled)
-                    return true;
-                var coordinates = SHelper.GameContent.Load<CoordinatesList>(dictPath);
-                bool added = false;
+                
+                bool found = CheckClickableComponents(__instance.points, __instance.xPositionOnScreen, __instance.yPositionOnScreen, x, y);
+                return !found;
+            }
+        }
+
+        [HarmonyPatch(typeof(IClickableMenu), nameof(IClickableMenu.receiveLeftClick))]
+        public class RSVMapPage_receiveLeftClick_Patch
+        {
+            public static bool Prefix(IClickableMenu __instance, int x, int y)
+            {
+
                 bool found = false;
-                foreach (ClickableComponent c in __instance.points)
+                if (__instance.allClickableComponents != null && __instance.GetType().Name == "RSVWorldMap")
                 {
-                    Coordinates co = coordinates.coordinates.Find(o => o.id == c.myID);
-                    if (co == null)
-                    {
-                        coordinates.coordinates.Add(new Coordinates() { name = c.name, id = c.myID, enabled = false });
-                        added = true;
-                        continue;
-                    }
-                    if (c.containsPoint(x, y) && co.enabled)
-                    {
-                        SMonitor.Log($"Teleporting to {c.name} ({c.myID}), {co.mapName}, {co.x},{co.y}", LogLevel.Debug);
-                        Game1.activeClickableMenu?.exitThisMenu(true);
-                        Game1.warpFarmer(co.mapName, co.x, co.y, false);
-                        found = true;
-                    }
-                }
-                if (added)
-                {
-                    SHelper.Data.WriteJsonFile(isSVE ? "sve_coordinates.json" : "coordinates.json", coordinates);
+                    // RSV uses component x,y's that are not offset, however they need to be offset to check for the mouse position
+                    found = CheckClickableComponents(__instance.allClickableComponents, 0, 0, x - __instance.xPositionOnScreen, y - __instance.yPositionOnScreen);
                 }
                 return !found;
             }
         }
-   }
+    }
 }

--- a/MapTeleport/CoordinatesList.cs
+++ b/MapTeleport/CoordinatesList.cs
@@ -1,11 +1,22 @@
 ﻿using Microsoft.Xna.Framework;
+using StardewValley.Menus;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MapTeleport
 {
     public class CoordinatesList
     {
         public List<Coordinates> coordinates = new List<Coordinates>();
+
+        public void AddAll(CoordinatesList other)
+        {
+            this.coordinates = this.coordinates.Concat(other.coordinates).ToList<Coordinates>();
+        }
+        public void Add(Coordinates other)
+        {
+            this.coordinates.Add(other);
+        }
     }
     public class Coordinates
     {
@@ -14,6 +25,7 @@ namespace MapTeleport
         public int x;
         public int y;
         public int id;
+        public string altId;
         public bool enabled = true;
     }
 }

--- a/MapTeleport/assets/coordinates.json
+++ b/MapTeleport/assets/coordinates.json
@@ -3,212 +3,212 @@
         {
             "id": 1001,
             "mapName": "Desert",
-            "x":6,
-            "y":52
+            "x": 6,
+            "y": 52
         },
         {
             "id": 1002,
             "mapName": "Farm",
-            "x":64,
-            "y":15
+            "x": 64,
+            "y": 15
         },
         {
             "id": 1003,
             "mapName": "Backwoods",
-            "x":22,
-            "y":16
+            "x": 22,
+            "y": 16
         },
         {
             "id": 1004,
             "mapName": "BusStop",
-            "x":14,
-            "y":22
+            "x": 14,
+            "y": 22
         },
         {
             "id": 1005,
             "mapName": "Forest",
-            "x":5,
-            "y":27
+            "x": 5,
+            "y": 27
         },
         {
             "id": 1006,
             "mapName": "Forest",
-            "x":90,
-            "y":16
+            "x": 90,
+            "y": 16
         },
         {
             "id": 1007,
             "mapName": "Forest",
-            "x":104,
-            "y":33
+            "x": 104,
+            "y": 33
         },
         {
             "id": 1008,
             "mapName": "Town",
-            "x":10,
-            "y":86
+            "x": 10,
+            "y": 86
         },
         {
             "id": 1009,
             "mapName": "Town",
-            "x":20,
-            "y":89
+            "x": 20,
+            "y": 89
         },
         {
             "id": 1010,
             "mapName": "Town",
-            "x":28,
-            "y":67
+            "x": 28,
+            "y": 67
         },
         {
             "id": 1011,
             "mapName": "Town",
-            "x":36,
-            "y":56
+            "x": 36,
+            "y": 56
         },
         {
             "id": 1012,
             "mapName": "Town",
-            "x":43,
-            "y":57
+            "x": 43,
+            "y": 57
         },
         {
             "id": 1013,
             "mapName": "Town",
-            "x":94,
-            "y":82
+            "x": 94,
+            "y": 82
         },
         {
             "id": 1014,
             "mapName": "Town",
-            "x":45,
-            "y":71
+            "x": 45,
+            "y": 71
         },
         {
             "id": 1015,
             "mapName": "Town",
-            "x":58,
-            "y":86
+            "x": 58,
+            "y": 86
         },
         {
             "id": 1016,
             "mapName": "Town",
-            "x":101,
-            "y":90
+            "x": 101,
+            "y": 90
         },
         {
             "id": 1017,
             "mapName": "Beach",
-            "x":49,
-            "y":11
+            "x": 49,
+            "y": 11
         },
         {
             "id": 1018,
             "mapName": "Town",
-            "x":34,
-            "y":97
+            "x": 34,
+            "y": 97
         },
         {
             "id": 1019,
             "mapName": "Town",
-            "x":46,
-            "y":90
+            "x": 46,
+            "y": 90
         },
         {
             "id": 1020, // Pam
             "mapName": "Town",
-            "x":72,
-            "y":69
+            "x": 72,
+            "y": 69
         },
         {
             "id": 1021,
             "mapName": "Town",
-            "x":57,
-            "y":64
+            "x": 57,
+            "y": 64
         },
         {
             "id": 1022,
             "mapName": "Mountain",
-            "x":12,
-            "y":26
+            "x": 12,
+            "y": 26
         },
         {
             "id": 1023,
             "mapName": "Mountain",
-            "x":29,
-            "y":8
+            "x": 29,
+            "y": 8
         },
         {
             "id": 1024,
             "mapName": "Mine",
-            "x":18,
-            "y":13
+            "x": 18,
+            "y": 13
         },
         {
             "id": 1025, // adventurer's guild
             "mapName": "Mountain",
-            "x":76,
-            "y":9
+            "x": 76,
+            "y": 9
         },
         {
             "id": 1026,
             "mapName": "Mountain",
-            "x":127,
-            "y":11
+            "x": 127,
+            "y": 11
         },
         {
             "id": 1027,
             "mapName": "Town",
-            "x":95,
-            "y":51
+            "x": 95,
+            "y": 51
         },
         {
             "id": 1028,
             "mapName": "Beach",
-            "x":30,
-            "y":34
+            "x": 30,
+            "y": 34
         },
         {
             "id": 1029,
             "mapName": "Railroad",
-            "x":10,
-            "y":57
+            "x": 10,
+            "y": 57
         },
         {
             "id": 1030,
             "mapName": "Woods",
-            "x":58,
-            "y":15
+            "x": 58,
+            "y": 15
         },
         {
             "id": 1031,
             "mapName": "Forest",
-            "x":34,
-            "y":96
+            "x": 34,
+            "y": 96
         },
         {
             "id": 1032,
             "mapName": "Town",
-            "x":52,
-            "y":20
+            "x": 52,
+            "y": 20
         },
         {
             "id": 1033,
             "mapName": "Forest",
-            "x":94,
-            "y":100
+            "x": 94,
+            "y": 100
         },
         {
             "id": 1034,
             "mapName": "Railroad",
-            "x":29,
-            "y":45
+            "x": 29,
+            "y": 45
         },
         {
             "id": 1035,
             "mapName": "IslandWest",
-            "x":77,
-            "y":41
+            "x": 77,
+            "y": 41
         },
     ]
 }

--- a/MapTeleport/assets/es_coordinates.json
+++ b/MapTeleport/assets/es_coordinates.json
@@ -1,0 +1,32 @@
+﻿{
+    "coordinates": [
+        {
+            "name": "East Scarp",
+            "altId": "945.285",
+            "mapName": "Custom_EastScarpe",
+            "x": 26,
+            "y": 57
+        },
+        {
+            "name": "Meadow Farm",
+            "altId": "1005.260",
+            "mapName": "Custom_ESMeadowFarm",
+            "x": 32,
+            "y": 35
+        },
+        {
+            "name": "The Orchard",
+            "altId": "1030.310",
+            "mapName": "Custom_ESOrchard",
+            "x": 5,
+            "y": 18
+        },
+        {
+            "name": "Deep Mountains",
+            "altId": "920.110",
+            "mapName": "Custom_ESDeepMountains",
+            "x": 54,
+            "y": 43
+        },
+    ]
+}

--- a/MapTeleport/assets/rsv_coordinates.json
+++ b/MapTeleport/assets/rsv_coordinates.json
@@ -1,0 +1,193 @@
+﻿{
+    "coordinates": [
+        {
+            "name": "Ridge Forest",
+            "altId": "370.5",
+            "mapName": "Custom_Ridgeside_RidgeForest",
+            "x": 80,
+            "y": 132
+        },
+        {
+            "name": "Ridge",
+            "altId": "455.55",
+            "mapName": "Custom_Ridgeside_Ridge",
+            "x": 89,
+            "y": 23
+        },
+        {
+            "name": "Ridge Falls",
+            "altId": "75.0",
+            "mapName": "Custom_Ridgeside_RidgeFalls",
+            "x": 39,
+            "y": 23
+        },
+        {
+            "name": "Blooming Hill Farm",
+            "altId": "55.200",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 22,
+            "y": 23
+        },
+        {
+            "name": "Heaps Convenience Store",
+            "altId": "305.180",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 79,
+            "y": 19
+        },
+        {
+            "name": "Daniels Residence",
+            "altId": "345.180",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 83,
+            "y": 20
+        },
+        {
+            "name": "Log Cabin Hotel",
+            "altId": "450.190",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 114,
+            "y": 24
+        },
+        {
+            "name": "Odd Jobs",
+            "altId": "545.205",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 133,
+            "y": 24
+        },
+        {
+            "name": "Pickens Residence",
+            "altId": "370.240",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 89,
+            "y": 29
+        },
+        {
+            "name": "Cable Car to Pelican Town",
+            "altId": "810.250",
+            "mapName": "Custom_Ridgeside_RSVCliff",
+            "x": 39,
+            "y": 19
+        },
+        {
+            "name": "Electrician's House",
+            "altId": "840.300",
+            "mapName": "Custom_Ridgeside_RSVCliff",
+            "x": 46,
+            "y": 33
+        },
+        {
+            "name": "Hike Trail",
+            "altId": "760.345",
+            "mapName": "Custom_Ridgeside_RSVTheHike",
+            "x": 33,
+            "y": 39
+        },
+        {
+            "name": "Starbound Stage",
+            "altId": "275.270",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 74,
+            "y": 43
+        },
+        {
+            "name": "Pika's Outdoor Restaurant",
+            "altId": "365.290",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 97,
+            "y": 42
+        },
+        {
+            "name": "Village Office",
+            "altId": "450.285",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 114,
+            "y": 42
+        },
+        {
+            "name": "Ridgeside Clinic",
+            "altId": "535.270",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 135,
+            "y": 37
+        },
+        {
+            "name": "Kobayashi Residence",
+            "altId": "540.320",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 130,
+            "y": 46
+        },
+        {
+            "name": "Amethyne Residence",
+            "altId": "520.390",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 129,
+            "y": 72
+        },
+        {
+            "name": "Ahn Yojeong Faye's Residence and Clothing Shop",
+            "altId": "420.375",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 105,
+            "y": 63
+        },
+        {
+            "name": "Community Greenhouse",
+            "altId": "380.430",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 96,
+            "y": 75
+        },
+        {
+            "name": "Akina Residence",
+            "altId": "300.385",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 75,
+            "y": 60
+        },
+        {
+            "name": "Rivera Residence",
+            "altId": "295.430",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 78,
+            "y": 73
+        },
+        {
+            "name": "Lola's Shed",
+            "altId": "15.325",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 7,
+            "y": 48
+        },
+        {
+            "name": "Bladebane Residence",
+            "altId": "40.390",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 14,
+            "y": 63
+        },
+        {
+            "name": "Nightingale Orchard",
+            "altId": "55.520",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 27,
+            "y": 98
+        },
+        {
+            "name": "Lidens Residence",
+            "altId": "285.610",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 76,
+            "y": 117
+        },
+        {
+            "name": "Water Research Facility",
+            "altId": "405.575",
+            "mapName": "Custom_Ridgeside_RidgesideVillage",
+            "x": 100,
+            "y": 112
+        },
+    ]
+}

--- a/MapTeleport/assets/sve_coordinates.json
+++ b/MapTeleport/assets/sve_coordinates.json
@@ -1,214 +1,305 @@
-﻿{
+{
     "coordinates": [
         {
             "id": 1001,
             "mapName": "Desert",
-            "x":29, 
-            "y":45
+            "x": 29,
+            "y": 45
         },
         {
             "id": 1002,
             "mapName": "Farm",
-            "x":64,
-            "y":15
+            "x": 64,
+            "y": 15
         },
         {
             "id": 1003,
             "mapName": "Backwoods",
-            "x":22,
-            "y":16
+            "x": 22,
+            "y": 16
         },
         {
             "id": 1004,
             "mapName": "BusStop",
-            "x":14,
-            "y":22
+            "x": 14,
+            "y": 22
         },
         {
             "id": 1005,
             "mapName": "Forest",
-            "x":5,
-            "y":27
+            "x": 5,
+            "y": 27
         },
         {
             "id": 1006,
             "mapName": "Forest",
-            "x":90,
-            "y":16
+            "x": 90,
+            "y": 16
         },
         {
             "id": 1007,
             "mapName": "Forest",
-            "x":104,
-            "y":33
+            "x": 104,
+            "y": 33
         },
         {
             "id": 1008,
             "mapName": "Town",
-            "x":10,
-            "y":86
+            "x": 10,
+            "y": 86
         },
         {
             "id": 1009,
             "mapName": "Town",
-            "x":20,
-            "y":89
+            "x": 20,
+            "y": 89
         },
         {
             "id": 1010,
             "mapName": "Town",
-            "x":28,
-            "y":67
+            "x": 28,
+            "y": 67
         },
         {
             "id": 1011,
             "mapName": "Town",
-            "x":36,
-            "y":56
+            "x": 36,
+            "y": 56
         },
         {
             "id": 1012,
             "mapName": "Town",
-            "x":43,
-            "y":57
+            "x": 43,
+            "y": 57
         },
         {
             "id": 1013,
             "mapName": "Town",
-            "x":94,
-            "y":82
+            "x": 94,
+            "y": 82
         },
         {
             "id": 1014,
             "mapName": "Town",
-            "x":45,
-            "y":71
+            "x": 45,
+            "y": 71
         },
         {
             "id": 1015,
             "mapName": "Town",
-            "x":58,
-            "y":86
+            "x": 58,
+            "y": 86
         },
         {
             "id": 1016,
             "mapName": "Town",
-            "x":101,
-            "y":90
+            "x": 101,
+            "y": 90
         },
         {
             "id": 1017,
             "mapName": "Beach",
-            "x":49,
-            "y":11
+            "x": 49,
+            "y": 11
         },
         {
             "id": 1018,
             "mapName": "Town",
-            "x":34,
-            "y":97
+            "x": 34,
+            "y": 97
         },
         {
             "id": 1019,
             "mapName": "Town",
-            "x":46,
-            "y":90
+            "x": 46,
+            "y": 90
         },
         {
             "id": 1020, // Pam
             "mapName": "Town",
-            "x":72,
-            "y":69
+            "x": 72,
+            "y": 69
         },
         {
             "id": 1021,
             "mapName": "Town",
-            "x":57,
-            "y":64
+            "x": 57,
+            "y": 64
         },
         {
             "id": 1022,
             "mapName": "Mountain",
-            "x":12,
-            "y":26
+            "x": 12,
+            "y": 26
         },
         {
             "id": 1023,
             "mapName": "Mountain",
-            "x":29,
-            "y":8
+            "x": 29,
+            "y": 8
         },
         {
             "id": 1024,
             "mapName": "Mine",
-            "x":18,
-            "y":13
+            "x": 18,
+            "y": 13
         },
         {
             "id": 1025, // adventurer's guild
             "mapName": "Town",
-            "x":33,
-            "y":101
+            "x": 33,
+            "y": 101
         },
         {
             "id": 1026,
             "mapName": "Mountain",
-            "x":127,
-            "y":11
+            "x": 127,
+            "y": 11
         },
         {
             "id": 1027,
             "mapName": "Town",
-            "x":95,
-            "y":51
+            "x": 95,
+            "y": 51
         },
         {
             "id": 1028,
             "mapName": "Beach",
-            "x":30,
-            "y":34
+            "x": 30,
+            "y": 34
         },
         {
             "id": 1029,
             "mapName": "Railroad",
-            "x":10,
-            "y":57
+            "x": 10,
+            "y": 57
         },
         {
             "id": 1030,
             "mapName": "Woods",
-            "x":58,
-            "y":15
+            "x": 58,
+            "y": 15
         },
         {
             "id": 1031,
             "mapName": "Forest",
-            "x":34,
-            "y":96
+            "x": 34,
+            "y": 96
         },
         {
             "id": 1032,
             "mapName": "Town",
-            "x":52,
-            "y":20
+            "x": 52,
+            "y": 20
         },
         {
             "id": 1033,
             "mapName": "Forest",
-            "x":94,
-            "y":100
+            "x": 94,
+            "y": 100
         },
         {
             "id": 1034,
             "mapName": "Railroad",
-            "x":29,
-            "y":45
+            "x": 29,
+            "y": 45
         },
         {
             "id": 1035,
             "mapName": "IslandWest",
-            "x":77,
-            "y":41
+            "x": 77,
+            "y": 41
+        },
+        {
+            "name": "Jenkins Residence",
+            "altId": "592.268",
+            "mapName": "Town",
+            "x": 59,
+            "y": 53
+        },
+        {
+            "name": "Adventurer Guild",
+            "altId": "748.40",
+            "mapName": "Custom_AdventurerSummit",
+            "x": 32,
+            "y": 22
+        },
+        {
+            "name": "Community Garden",
+            "altId": "716.448",
+            "mapName": "Town",
+            "x": 102,
+            "y": 102
+        },
+        {
+            "name": "Shearwater Bridge",
+            "altId": "875.339",
+            "mapName": "Custom_ShearwaterBridge",
+            "x": 30,
+            "y": 22
+        },
+        {
+            "name": "Beach",
+            "altId": "572.536",
+            "mapName": "Beach",
+            "x": 79,
+            "y": 13
+        },
+        {
+            "name": "Andy's House",
+            "altId": "217.524",
+            "mapName": "Forest",
+            "x": 62,
+            "y": 67
+        },
+        {
+            "name": "Fairhaven Farm",
+            "altId": "256.520",
+            "mapName": "Forest",
+            "x": 68,
+            "y": 72
+        },
+        {
+            "name": "Sophia's House",
+            "altId": "438.468",
+            "mapName": "Custom_BlueMoonVineyard",
+            "x": 28,
+            "y": 36
+        },
+        {
+            "name": "Blue Moon Vineyard",
+            "altId": "400.472",
+            "mapName": "Custom_BlueMoonVineyard",
+            "x": 28,
+            "y": 36
+        },
+        {
+            "name": "Marnie's Farm",
+            "altId": "216.416",
+            "mapName": "Forest",
+            "x": 63,
+            "y": 24
+        },
+        {
+            "name": "Grandpa's Shed",
+            "altId": "388.256",
+            "mapName": "Farm",
+            "x": 138,
+            "y": 36
+        },
+        {
+            "name": "Memorial",
+            "altId": "732.200",
+            "mapName": "Town",
+            "x": 111,
+            "y": 27
+        },
+        {
+            "name": "Old Community Garden",
+            "altId": "788.386",
+            "mapName": "Custom_Garden",
+            "x": 23,
+            "y": 27
         },
     ]
 }


### PR DESCRIPTION
Added an alt id option based off of the positions of the clickable map entries, allowing MapTeleport to identify entries without ids mostly found in mods.
Positions are normalized for screen sizes.
Cleaned up the file reads to only pull in those that are needed.
Cleaned up the coordinate dictionary such that it only contains the entries that that are not configured.

RSV will require the PR https://github.com/Rafseazz/Ridgeside-Village-Mod/pull/168 to work, but it will not break without it.
