### PR TITLE
Mobile phone update for 1.6

### DIFF
--- a/MobilePhone/CarpenterPhoneMenu.cs
+++ b/MobilePhone/CarpenterPhoneMenu.cs
@@ -12,7 +12,6 @@ namespace MobilePhone
         {
             this.helper = helper;
             exitFunction = OnExit;
-
         }
 
         public void OnExit()

--- a/MobilePhone/MobilePhoneApp.cs
+++ b/MobilePhone/MobilePhoneApp.cs
@@ -7,9 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 
 namespace MobilePhone
 {

--- a/MobilePhone/MobilePhoneCall.cs
+++ b/MobilePhone/MobilePhoneCall.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using MobilePhone.Api;
 using StardewModdingAPI;
+using StardewModdingAPI.Framework.ModLoading.Rewriters.StardewValley_1_6;
 using StardewValley;
 using StardewValley.Menus;
 using System;
@@ -96,7 +97,7 @@ namespace MobilePhone
             }
             else if (whichAnswer == "PhoneApp_InCall_GoodBye")
             {
-                Game1.DrawDialogue(npc, GetGoodBye(npc));
+                Game1.DrawDialogue(new Dialogue(npc, null, GetGoodBye(npc)));
                 EndCall();
             }
         }
@@ -289,7 +290,7 @@ namespace MobilePhone
             {
                 ShowMainCallDialogue(npc);
             }));
-            Game1.DrawDialogue(npc, message);
+            Game1.DrawDialogue(new Dialogue(npc, null, message));
         }
         private static void InviteOnPhone(NPC npc)
         {
@@ -501,7 +502,7 @@ namespace MobilePhone
 
             if (ModEntry.npcAdventureModApi?.CanRecruit(Game1.player, npc) == true)
             {
-                Game1.DrawDialogue(npc, Helper.Translation.Get("recruit-success"));
+                Game1.DrawDialogue(npc, "recruit-success");
                 Game1.afterDialogues = delegate ()
                 {
                     DoRecruit(npc);
@@ -509,7 +510,7 @@ namespace MobilePhone
             }
             else
             {
-                Game1.DrawDialogue(npc, Helper.Translation.Get("recruit-fail"));
+                Game1.DrawDialogue(npc, "recruit-fail");
                 Game1.afterDialogues = delegate ()
                 {
                     ShowMainCallDialogue(npc);

--- a/MobilePhone/MobilePhoneCall.cs
+++ b/MobilePhone/MobilePhoneCall.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using MobilePhone.Api;
 using StardewModdingAPI;
-using StardewModdingAPI.Framework.ModLoading.Rewriters.StardewValley_1_6;
 using StardewValley;
 using StardewValley.Menus;
 using System;

--- a/MobilePhone/ModEntry.cs
+++ b/MobilePhone/ModEntry.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MobilePhone.Api;
 using StardewModdingAPI;
-using StardewModdingAPI.Framework.ModLoading.Rewriters.StardewValley_1_6;
 using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Network;

--- a/MobilePhone/ModEntry.cs
+++ b/MobilePhone/ModEntry.cs
@@ -112,7 +112,7 @@ namespace MobilePhone
         public static bool isReminiscingAtNight;
         public static Event reminisceEvent;
         public static bool buildingInCall;
-        
+
         public static List<string> calledToday = new List<string>();
 
         public static event EventHandler OnScreenRotated;
@@ -141,8 +141,8 @@ namespace MobilePhone
             PhoneUtils.Initialize(Helper, Monitor, Config);
             PhonePatches.Initialize(Helper, Monitor, Config);
 
-            if(Config.AddRotateApp)
-                apps.Add(Helper.ModRegistry.ModID+"_Rotate", new MobileApp(helper.Translation.Get("rotate-phone"), null, helper.ModContent.Load<Texture2D>("assets/rotate_icon.png")));
+            if (Config.AddRotateApp)
+                apps.Add(Helper.ModRegistry.ModID + "_Rotate", new MobileApp(helper.Translation.Get("rotate-phone"), null, helper.ModContent.Load<Texture2D>("assets/rotate_icon.png")));
 
             var harmony = new Harmony(ModManifest.UniqueID);
 
@@ -155,7 +155,7 @@ namespace MobilePhone
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_endBehaviors_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Farmer), nameof(Farmer.addItemToInventory), new Type[] {typeof(Item), typeof(List<Item>) }),
+                original: AccessTools.Method(typeof(Farmer), nameof(Farmer.addItemToInventory), new Type[] { typeof(Item), typeof(List<Item>) }),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Farmer_addItemToInventory_prefix))
             );
             harmony.Patch(
@@ -174,11 +174,10 @@ namespace MobilePhone
                 original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.AwardFestivalPrize)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
-            // <-- Depricated -->
-            // harmony.Patch(
-            //     original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.AddTool)),
-            //     prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
-            // );
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.AddItem)),
+                prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
+            );
             harmony.Patch(
                 original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.AddConversationTopic)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
@@ -237,7 +236,7 @@ namespace MobilePhone
             Helper.Events.GameLoop.SaveLoaded += PhoneGameLoop.GameLoop_SaveLoaded;
             Helper.Events.GameLoop.GameLaunched += PhoneGameLoop.GameLoop_GameLaunched;
             Helper.Events.GameLoop.ReturnedToTitle += PhoneGameLoop.ReturnedToTitle;
-            Helper.Events.GameLoop.DayStarted += PhoneGameLoop.GameLoop_DayStarted; 
+            Helper.Events.GameLoop.DayStarted += PhoneGameLoop.GameLoop_DayStarted;
             Helper.Events.GameLoop.TimeChanged += PhoneGameLoop.GameLoop_TimeChanged;
             Helper.Events.GameLoop.OneSecondUpdateTicked += PhoneGameLoop.GameLoop_OneSecondUpdateTicked;
             Helper.Events.Display.WindowResized += PhoneVisuals.Display_WindowResized;
@@ -274,7 +273,7 @@ namespace MobilePhone
                         foreach (EventFork fork in invite.forks)
                         {
                             var f = fork;
-                            e.Edit(delegate(IAssetData obj) {
+                            e.Edit(delegate (IAssetData obj) {
                                 var dict = obj.AsDictionary<string, string>();
                                 dict.Data.Add(fork.key, MobilePhoneCall.CreateEventString(fork.nodes, invitedNPC));
 

--- a/MobilePhone/ModEntry.cs
+++ b/MobilePhone/ModEntry.cs
@@ -3,12 +3,12 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MobilePhone.Api;
 using StardewModdingAPI;
+using StardewModdingAPI.Framework.ModLoading.Rewriters.StardewValley_1_6;
 using StardewValley;
 using StardewValley.Menus;
 using StardewValley.Network;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 
 namespace MobilePhone
@@ -127,7 +127,9 @@ namespace MobilePhone
             SHelper = helper;
             SMonitor = Monitor;
             if (!Config.EnableMod)
+            {
                 return;
+            }
 
             api = (MobilePhoneApi)GetApi();
 
@@ -150,7 +152,7 @@ namespace MobilePhone
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Game1_pressSwitchToolButton_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.endBehaviors)),
+                original: AccessTools.Method(typeof(Event), nameof(Event.endBehaviors), new Type[] { typeof(string[]), typeof(GameLocation) }),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_endBehaviors_prefix))
             );
             harmony.Patch(
@@ -170,47 +172,48 @@ namespace MobilePhone
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.GameLocation_answerDialogue_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.AwardFestivalPrize)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.AwardFestivalPrize)),
+                prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
+            );
+            // <-- Depricated -->
+            // harmony.Patch(
+            //     original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.AddTool)),
+            //     prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
+            // );
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.AddConversationTopic)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.AddTool)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.AddCookingRecipe)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.AddConversationTopic)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.AddCraftingRecipe)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.AddCookingRecipe)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.Money)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.AddCraftingRecipe)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.RemoveItem)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.Money)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.Friendship)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.RemoveItem)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.Dump)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.Friendship)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.AddQuest)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
             );
             harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.Dump)),
-                prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
-            );
-            harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.AddQuest)),
-                prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_prefix))
-            );
-            harmony.Patch(
-                original: AccessTools.Method(typeof(Event), nameof(Event.DefaultCommands.Cutscene)),
+                original: AccessTools.Method(typeof(Event.DefaultCommands), nameof(Event.DefaultCommands.Cutscene)),
                 prefix: new HarmonyMethod(typeof(PhonePatches), nameof(PhonePatches.Event_command_cutscene_prefix))
             );
             harmony.Patch(

--- a/MobilePhone/PhonePatches.cs
+++ b/MobilePhone/PhonePatches.cs
@@ -358,11 +358,23 @@ namespace MobilePhone
             }
             if (CurrentBlueprint.BuildDays <= 0)
             {
-                Game1.DrawDialogue(Game1.getCharacterFromName("Robin", true), Game1.content.LoadString("Data\\ExtraDialogue:Robin_Instant", (LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.de) ? CurrentBlueprint.DisplayName : CurrentBlueprint.DisplayName.ToLower()));
+                var npc = Game1.getCharacterFromName("Robin", true);
+                var dialog = Game1.content.LoadString("Data\\ExtraDialogue:Robin_Instant", (LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.de) 
+                    ? CurrentBlueprint.DisplayName 
+                    : CurrentBlueprint.DisplayName.ToLower());
+                Game1.DrawDialogue(new Dialogue(npc, null, dialog));
             }
             else
             {
-                Game1.DrawDialogue(Game1.getCharacterFromName("Robin", true), Game1.content.LoadString(dialoguePath, (LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.de) ? CurrentBlueprint.DisplayName : CurrentBlueprint.DisplayName.ToLower(), (LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.de) ? CurrentBlueprint.DisplayName.Split(' ').Last().Split('-').Last() : ((LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.pt || LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.es || LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.it) ? CurrentBlueprint.DisplayName.ToLower().Split(' ').First() : CurrentBlueprint.DisplayName.ToLower().Split(' ').Last())));
+                var npc = Game1.getCharacterFromName("Robin", true);
+                var dialog = Game1.content.LoadString(dialoguePath, (LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.de) 
+                    ? CurrentBlueprint.DisplayName 
+                    : CurrentBlueprint.DisplayName.ToLower(), (LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.de) 
+                        ? CurrentBlueprint.DisplayName.Split(' ').Last().Split('-').Last() 
+                        : ((LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.pt || LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.es || LocalizedContentManager.CurrentLanguageCode == LocalizedContentManager.LanguageCode.it) 
+                            ? CurrentBlueprint.DisplayName.ToLower().Split(' ').First() 
+                            : CurrentBlueprint.DisplayName.ToLower().Split(' ').Last()));
+                Game1.DrawDialogue(new Dialogue(npc, null, dialog));
             }
 
             while (Game1.activeClickableMenu is DialogueBox)

--- a/MobilePhone/PhonePatches.cs
+++ b/MobilePhone/PhonePatches.cs
@@ -63,7 +63,7 @@ namespace MobilePhone
                     Monitor.Log($"Reminiscing at night");
                     __instance.LightLevel = 0f;
                     //Game1.globalOutdoorLighting = 1f;
-                    float transparency = Math.Min(0.93f, 0.75f + (2400 - Game1.getTrulyDarkTime(Game1.currentLocation) + Game1.gameTimeInterval / 7000f * 16.6f) * 0.000625f);
+                    float transparency = Math.Min(0.93f, 0.75f + (2400 - Game1.getTrulyDarkTime(__instance) + Game1.gameTimeInterval / 7000f * 16.6f) * 0.000625f);
                     Game1.outdoorLight = Game1.eveningColor * transparency;
                     if (!(__instance is MineShaft) && __instance is not Woods)
                     {
@@ -136,47 +136,45 @@ namespace MobilePhone
                     return false;
                 }
             }
-            else
-            {
-                if (Game1.currentMinigame != null)
-                {
-                    return true;
-                }
 
-                switch (value)
+            if (Game1.currentMinigame != null)
+            {
+                return true;
+            }
+
+            switch (value)
+            {
+                case "EventInvite_balloonChangeMap":
                 {
-                    case "EventInvite_balloonChangeMap":
+                    context.Location.TemporarySprites.Add(new TemporaryAnimatedSprite("LooseSprites\\Cursors", new Microsoft.Xna.Framework.Rectangle(0, 1183, 84, 160), 10000f, 1, 99999, new Vector2(22f, 36f) * 64f + new Vector2(-23f, 0f) * 4f, false, false, 2E-05f, 0f, Color.White, 4f, 0f, 0f, 0f, false)
                     {
-                        context.Location.TemporarySprites.Add(new TemporaryAnimatedSprite("LooseSprites\\Cursors", new Microsoft.Xna.Framework.Rectangle(0, 1183, 84, 160), 10000f, 1, 99999, new Vector2(22f, 36f) * 64f + new Vector2(-23f, 0f) * 4f, false, false, 2E-05f, 0f, Color.White, 4f, 0f, 0f, 0f, false)
-                        {
-                            motion = new Vector2(0f, -2f),
-                            yStopCoordinate = 576,
-                            reachedStopCoordinate = new TemporaryAnimatedSprite.endBehavior(balloonInSky),
-                            attachedCharacter = @event.farmer,
-                            id = 1
-                        });
-                        context.Location.TemporarySprites.Add(new TemporaryAnimatedSprite("LooseSprites\\Cursors", new Microsoft.Xna.Framework.Rectangle(84, 1205, 38, 26), 10000f, 1, 99999, new Vector2(22f, 36f) * 64f + new Vector2(0f, 134f) * 4f, false, false, 0.2625f, 0f, Color.White, 4f, 0f, 0f, 0f, false)
-                        {
-                            motion = new Vector2(0f, -2f),
-                            id = 2,
-                            attachedCharacter = @event.getActorByName(ModEntry.invitedNPC.Name)
-                        });
-                        @event.CurrentCommand++;
-                        Game1.globalFadeToClear(null, 0.01f);
-                        return false;
-                    }
-                    case "EventInvite_balloonDepart":
+                        motion = new Vector2(0f, -2f),
+                        yStopCoordinate = 576,
+                        reachedStopCoordinate = new TemporaryAnimatedSprite.endBehavior(balloonInSky),
+                        attachedCharacter = @event.farmer,
+                        id = 1
+                    });
+                    context.Location.TemporarySprites.Add(new TemporaryAnimatedSprite("LooseSprites\\Cursors", new Microsoft.Xna.Framework.Rectangle(84, 1205, 38, 26), 10000f, 1, 99999, new Vector2(22f, 36f) * 64f + new Vector2(0f, 134f) * 4f, false, false, 0.2625f, 0f, Color.White, 4f, 0f, 0f, 0f, false)
                     {
-                        TemporaryAnimatedSprite temporarySpriteByID = context.Location.getTemporarySpriteByID(1);
-                        temporarySpriteByID.attachedCharacter = @event.farmer;
-                        temporarySpriteByID.motion = new Vector2(0f, -2f);
-                        TemporaryAnimatedSprite temporarySpriteByID2 = context.Location.getTemporarySpriteByID(2);
-                        temporarySpriteByID2.attachedCharacter = @event.getActorByName(ModEntry.invitedNPC.Name);
-                        temporarySpriteByID2.motion = new Vector2(0f, -2f);
-                        context.Location.getTemporarySpriteByID(3).scaleChange = -0.01f;
-                        @event.CurrentCommand++;
-                        return false;
-                    }
+                        motion = new Vector2(0f, -2f),
+                        id = 2,
+                        attachedCharacter = @event.getActorByName(ModEntry.invitedNPC.Name)
+                    });
+                    @event.CurrentCommand++;
+                    Game1.globalFadeToClear(null, 0.01f);
+                    return false;
+                }
+                case "EventInvite_balloonDepart":
+                {
+                    TemporaryAnimatedSprite temporarySpriteByID = context.Location.getTemporarySpriteByID(1);
+                    temporarySpriteByID.attachedCharacter = @event.farmer;
+                    temporarySpriteByID.motion = new Vector2(0f, -2f);
+                    TemporaryAnimatedSprite temporarySpriteByID2 = context.Location.getTemporarySpriteByID(2);
+                    temporarySpriteByID2.attachedCharacter = @event.getActorByName(ModEntry.invitedNPC.Name);
+                    temporarySpriteByID2.motion = new Vector2(0f, -2f);
+                    context.Location.getTemporarySpriteByID(3).scaleChange = -0.01f;
+                    @event.CurrentCommand++;
+                    return false;
                 }
             }
             
@@ -208,12 +206,12 @@ namespace MobilePhone
             }
             return true;
         }
-        public static bool Event_endBehaviors_prefix(string[] args, GameLocation location)
+        public static bool Event_endBehaviors_prefix(ref Event __instance, string[] args, GameLocation location)
         {
             if (ModEntry.isReminiscing)
             {
                 Monitor.Log($"Reminiscing, will not execute end behaviors {string.Join(" ", args)}");
-                location.currentEvent.exitEvent();
+                __instance.exitEvent();
                 return false;
             }
             return true;

--- a/MobilePhone/PhonePatches.cs
+++ b/MobilePhone/PhonePatches.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
 using StardewModdingAPI;
-using StardewModdingAPI.Framework.ModLoading.Rewriters.StardewValley_1_6;
 using StardewValley;
 using StardewValley.Buildings;
 using StardewValley.Characters;

--- a/MobilePhone/PhonePatches.cs
+++ b/MobilePhone/PhonePatches.cs
@@ -289,7 +289,7 @@ namespace MobilePhone
             {
                 RefreshView1();
             };
-            Game1.warpFarmer(locationRequest.Location.Name, Game1.player.TilePoint.X, Game1.player.TilePoint.Y, Game1.player.FacingDirection);
+            Game1.warpFarmer(locationRequest, Game1.player.TilePoint.X, Game1.player.TilePoint.Y, Game1.player.FacingDirection);
             return false;
         }
 
@@ -303,7 +303,7 @@ namespace MobilePhone
                 RefreshView2();
 
             };
-            Game1.warpFarmer(locationRequest.Location.Name, Game1.player.TilePoint.X, Game1.player.TilePoint.Y, Game1.player.FacingDirection);
+            Game1.warpFarmer(locationRequest, Game1.player.TilePoint.X, Game1.player.TilePoint.Y, Game1.player.FacingDirection);
             return false;
         }
         private static void RefreshView1()
@@ -316,6 +316,7 @@ namespace MobilePhone
             Helper.Reflection.GetMethod(Game1.activeClickableMenu, "resetBounds").Invoke(new object[] { });
             Helper.Reflection.GetField<bool>(Game1.activeClickableMenu, "upgrading").SetValue(false);
             Helper.Reflection.GetField<bool>(Game1.activeClickableMenu, "moving").SetValue(false);
+            Helper.Reflection.GetField<bool>(Game1.activeClickableMenu, "painting").SetValue(false);
             Helper.Reflection.GetField<Building>(Game1.activeClickableMenu, "buildingToMove").SetValue(null);
             Helper.Reflection.GetField<bool>(Game1.activeClickableMenu, "freeze").SetValue(false);
             Game1.displayHUD = true;

--- a/MobilePhone/ThemeApp.cs
+++ b/MobilePhone/ThemeApp.cs
@@ -110,10 +110,10 @@ namespace MobilePhone
                 }
             }
 
-
-            if (Directory.Exists(Path.Combine(Helper.DirectoryPath, "assets", "ringtones")))
+            string fullpath = Path.Combine(Helper.DirectoryPath, "assets", "ringtones");
+            if (Directory.Exists(fullpath))
             {
-                string[] rings = Directory.GetFiles(Path.Combine(Helper.DirectoryPath, "assets", "ringtones"), "*.wav");
+                string[] rings = Directory.GetFiles(fullpath, "*.wav");
                 foreach (string path in rings)
                 {
                     try
@@ -141,12 +141,13 @@ namespace MobilePhone
                         Monitor.Log($"Couldn't load ring {path}:\r\n{ex}", LogLevel.Error);
                     }
                 }
-                rings = Config.BuiltInRingTones.Split(',');
-                foreach (string ring in rings)
-                {
-                    ringDict.Add(ring, null);
-                }
             }
+
+            foreach (string ring in Config.BuiltInRingTones.Split(','))
+            {
+                ringDict.Add(ring, null);
+            }
+
             ringList = ringDict.Keys.ToList();
             skinList = skinDict.Keys.ToList();
             backgroundList = backgroundDict.Keys.ToList();

--- a/MobilePhone/ThemeApp.cs
+++ b/MobilePhone/ThemeApp.cs
@@ -381,11 +381,15 @@ namespace MobilePhone
                         continue;
                     }
                     if (ringList[i] == Config.PhoneRingTone)
+                    {
                         e.SpriteBatch.Draw(ModEntry.ringListHighlightTexture, new Rectangle((int)(itemPos.X), (int)itemPos.Y, (int)(screenSize.X), Config.RingListItemHeight), Color.White);
+                    }
 
                     string itemName = ringList[i];
                     if (itemName.Contains(":"))
+                    {
                         itemName = itemName.Split(':')[1];
+                    }
                     e.SpriteBatch.DrawString(Game1.dialogueFont, itemName, itemPos, Config.RingListItemColor, 0, Vector2.Zero, Config.RingListItemScale, SpriteEffects.None, 0.86f);
                 }
             }

--- a/MobilePhone/manifest.json
+++ b/MobilePhone/manifest.json
@@ -1,11 +1,11 @@
 ﻿{
   "Name": "Mobile Phone",
   "Author": "aedenthorn",
-  "Version": "3.2.2",
+  "Version": "4.0.0",
   "Description": "Gives you a mobile phone.",
   "UniqueID": "aedenthorn.MobilePhone",
   "EntryDll": "MobilePhone.dll",
-  "MinimumApiVersion": "3.15.0",
+  "MinimumApiVersion": "4.0.0",
   "UpdateKeys": [ "Nexus:6523" ],
   "ModUpdater": {
     "Repository": "StardewValleyMods",


### PR DESCRIPTION
Updates the Mobile Phone mod for 1.6.

**Changes made**
- Updated method bindings (and one implementation) in `ModEntry.cs` harmony patches to reflect changes to their patch targets. This is enough to run the game without any errors unless the mobile phone is used to call someone.

- Changed calls to `Game1.DrawDialogue` to another overloaded method that can can take dialog text directly (as opposed to an translation key). This prevents errors when displaying dialog text without translations (such as the generic goodbye when ending calls).

I have tested Reminiscing a couple events and calling npc's without errors. The settings seems to work as intended, although my changes should not affect them. More testing could be required but for now everything seems to be working.
