### PR TITLE
[PlannedParenthood] Remove Harmony Patchall

### DIFF
--- a/PlannedParenthood/CodePatches.cs
+++ b/PlannedParenthood/CodePatches.cs
@@ -54,136 +54,123 @@ namespace PlannedParenthood
             return names;
         }
 
-        [HarmonyPatch(typeof(GameLocation), nameof(GameLocation.answerDialogueAction))]
-        public class GameLocation_answerDialogueAction_Patch
+        public static bool GameLocation_answerDialogueAction_Prefix(GameLocation __instance, ref string questionAndAnswer, ref bool __result)
         {
-            public static bool Prefix(GameLocation __instance, ref string questionAndAnswer, ref bool __result)
-            {
-                if (!Config.ModEnabled)
-                    return true;
-                partnerName = null;
-                if (questionAndAnswer == "Sleep_Baby")
-                {
-                    SMonitor.Log("Starting baby dialogue");
-
-                    CreateNameListQuestion(__instance);
-
-                    __result = true;
-                    return false;
-                }
-                else if (questionAndAnswer.StartsWith("SleepBaby_"))
-                {
-                    string name = questionAndAnswer.Substring("SleepBaby_".Length);
-                    if (name == "prev_page")
-                    {
-                        namePage--;
-                        CreateNameListQuestion(__instance);
-                    }
-                    else if (name == "next_page")
-                    {
-                        namePage++;
-                        CreateNameListQuestion(__instance);
-                    }
-                    else
-                    {
-                        partnerName = name;
-                        SMonitor.Log($"Trying to make baby with {partnerName}");
-                        questionAndAnswer = "Sleep_Yes";
-                        return true;
-                    }
-                    __result = true;
-                    return false;
-                }
+            if (!Config.ModEnabled)
                 return true;
-            }
-            private static void CreateNameListQuestion(GameLocation __instance)
+            partnerName = null;
+            if (questionAndAnswer == "Sleep_Baby")
             {
-                var names = GetSpouseNames();
+                SMonitor.Log("Starting baby dialogue");
 
-                int totalNames = names.Count;
+                CreateNameListQuestion(__instance);
 
-                names = names.Skip(namePage * Config.NamesPerPage).Take(Config.NamesPerPage).ToList();
-
-                List<Response> responses = new List<Response>();
-
-                if (namePage > 0)
-                    responses.Add(new Response("prev_page", "..."));
-                foreach (var name in names)
-                {
-                    responses.Add(new Response(name, name));
-                }
-                if (Config.NamesPerPage * (namePage + 1) < totalNames)
-                    responses.Add(new Response("next_page", "..."));
-
-                __instance.createQuestionDialogue(SHelper.Translation.Get("which-npc"), responses.ToArray(), "SleepBaby");
-            }
-        }
-
-        [HarmonyPatch(typeof(GameLocation), nameof(GameLocation.createQuestionDialogue), new Type[] { typeof(string), typeof(Response[]), typeof(string), typeof(Object) })]
-        public class GameLocation_createQuestionDialogue_Patch
-        {
-            public static void Prefix(GameLocation __instance, ref string question, ref Response[] answerChoices, string dialogKey)
-            {
-                if (!Config.ModEnabled || dialogKey != "Sleep")
-                    return;
-                SMonitor.Log($"Showing sleep confirmation");
-
-                var fh = Utility.getHomeOfFarmer(Game1.player);
-                
-                if (fh.upgradeLevel < 2)
-                {
-                    SMonitor.Log($"Cannot ask about pregnancy; farmhouse level {fh.upgradeLevel}", LogLevel.Debug);
-                    return;
-                }
-                if (fh.cribStyle.Value <= 0)
-                {
-                    SMonitor.Log($"Cannot ask about pregnancy; no crib", LogLevel.Debug);
-                    return;
-                }
-
-                partnerName = null;
-
-                var names = GetSpouseNames();
-                if (!names.Any())
-                {
-                    SMonitor.Log($"Cannot ask about pregnancy; no applicable spouses", LogLevel.Debug);
-                    return;
-                }
-
-                var list = answerChoices.ToList();
-                list.Add(new Response("Baby", SHelper.Translation.Get("make-baby")));
-                answerChoices = list.ToArray();
-            }
-
-        }
-        [HarmonyPatch(typeof(Utility), nameof(Utility.pickPersonalFarmEvent))]
-        public class Utility_pickPersonalFarmEvent_Patch
-        {
-
-            public static bool Prefix(ref FarmEvent __result)
-            {
-                if (!Config.ModEnabled || partnerName is null)
-                    return true;
-                if (Game1.weddingToday)
-                {
-                    __result = null;
-                    return false;
-                }
-                if (freeLoveAPI is not null)
-                    freeLoveAPI.SetLastPregnantSpouse(partnerName);
-
-                if (Game1.player.friendshipData.ContainsKey(partnerName))
-                {
-                    SMonitor.Log($"creating NPC pregnancy event with {partnerName}");
-                    __result = new QuestionEvent(1);
-                }
-                else if(Game1.getAllFarmers().ToList().Exists(f => f.Name == partnerName))
-                {
-                    SMonitor.Log($"creating PC pregnancy event with {partnerName}");
-                    __result = new QuestionEvent(3);
-                }
+                __result = true;
                 return false;
             }
+            else if (questionAndAnswer.StartsWith("SleepBaby_"))
+            {
+                string name = questionAndAnswer.Substring("SleepBaby_".Length);
+                if (name == "prev_page")
+                {
+                    namePage--;
+                    CreateNameListQuestion(__instance);
+                }
+                else if (name == "next_page")
+                {
+                    namePage++;
+                    CreateNameListQuestion(__instance);
+                }
+                else
+                {
+                    partnerName = name;
+                    SMonitor.Log($"Trying to make baby with {partnerName}");
+                    questionAndAnswer = "Sleep_Yes";
+                    return true;
+                }
+                __result = true;
+                return false;
+            }
+            return true;
+        }
+        private static void CreateNameListQuestion(GameLocation __instance)
+        {
+            var names = GetSpouseNames();
+
+            int totalNames = names.Count;
+
+            names = names.Skip(namePage * Config.NamesPerPage).Take(Config.NamesPerPage).ToList();
+
+            List<Response> responses = new List<Response>();
+
+            if (namePage > 0)
+                responses.Add(new Response("prev_page", "..."));
+            foreach (var name in names)
+            {
+                responses.Add(new Response(name, name));
+            }
+            if (Config.NamesPerPage * (namePage + 1) < totalNames)
+                responses.Add(new Response("next_page", "..."));
+
+            __instance.createQuestionDialogue(SHelper.Translation.Get("which-npc"), responses.ToArray(), "SleepBaby");
+        }
+       
+        public static void GameLocation_createQuestionDialogue_Prefix(GameLocation __instance, ref string question, ref Response[] answerChoices, string dialogKey)
+        {
+            if (!Config.ModEnabled || dialogKey != "Sleep")
+                return;
+            SMonitor.Log($"Showing sleep confirmation");
+
+            var fh = Utility.getHomeOfFarmer(Game1.player);
+                
+            if (fh.upgradeLevel < 2)
+            {
+                SMonitor.Log($"Cannot ask about pregnancy; farmhouse level {fh.upgradeLevel}", LogLevel.Debug);
+                return;
+            }
+            if (fh.cribStyle.Value <= 0)
+            {
+                SMonitor.Log($"Cannot ask about pregnancy; no crib", LogLevel.Debug);
+                return;
+            }
+
+            partnerName = null;
+
+            var names = GetSpouseNames();
+            if (!names.Any())
+            {
+                SMonitor.Log($"Cannot ask about pregnancy; no applicable spouses", LogLevel.Debug);
+                return;
+            }
+
+            var list = answerChoices.ToList();
+            list.Add(new Response("Baby", SHelper.Translation.Get("make-baby")));
+            answerChoices = list.ToArray();
+        }
+
+        public static bool Utility_pickPersonalFarmEvent_Prefix(ref FarmEvent __result)
+        {
+            if (!Config.ModEnabled || partnerName is null)
+                return true;
+            if (Game1.weddingToday)
+            {
+                __result = null;
+                return false;
+            }
+            if (freeLoveAPI is not null)
+                freeLoveAPI.SetLastPregnantSpouse(partnerName);
+
+            if (Game1.player.friendshipData.ContainsKey(partnerName))
+            {
+                SMonitor.Log($"creating NPC pregnancy event with {partnerName}");
+                __result = new QuestionEvent(1);
+            }
+            else if(Game1.getAllFarmers().ToList().Exists(f => f.Name == partnerName))
+            {
+                SMonitor.Log($"creating PC pregnancy event with {partnerName}");
+                __result = new QuestionEvent(3);
+            }
+            return false;
         }
     }
 }

--- a/PlannedParenthood/ModEntry.cs
+++ b/PlannedParenthood/ModEntry.cs
@@ -1,5 +1,7 @@
 ﻿using HarmonyLib;
 using StardewModdingAPI;
+using StardewValley;
+using System;
 
 namespace PlannedParenthood
 {
@@ -30,11 +32,24 @@ namespace PlannedParenthood
             SMonitor = Monitor;
             SHelper = helper;
 
-            helper.Events.GameLoop.GameLaunched += GameLoop_GameLaunched;
-
             var harmony = new Harmony(ModManifest.UniqueID);
-            harmony.PatchAll();
 
+            harmony.Patch(
+               original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.answerDialogueAction)),
+               prefix: new HarmonyMethod(typeof(ModEntry), nameof(GameLocation_answerDialogueAction_Prefix))
+            );
+
+            harmony.Patch(
+               original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.createQuestionDialogue), new Type[] { typeof(string), typeof(Response[]), typeof(string), typeof(StardewValley.Object) }),
+               prefix: new HarmonyMethod(typeof(ModEntry), nameof(GameLocation_createQuestionDialogue_Prefix))
+            );
+
+            harmony.Patch(
+               original: AccessTools.Method(typeof(Utility), nameof(Utility.pickPersonalFarmEvent)),
+               prefix: new HarmonyMethod(typeof(ModEntry), nameof(Utility_pickPersonalFarmEvent_Prefix))
+            );
+
+            helper.Events.GameLoop.GameLaunched += GameLoop_GameLaunched;
         }
         public override object GetApi()
         {

--- a/PlannedParenthood/PlannedParenthood.csproj
+++ b/PlannedParenthood/PlannedParenthood.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<EnableHarmony>true</EnableHarmony>
 	<Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/PlannedParenthood/manifest.json
+++ b/PlannedParenthood/manifest.json
@@ -1,11 +1,11 @@
 ﻿{
   "Name": "Planned Parenthood",
   "Author": "aedenthorn",
-  "Version": "0.2.5",
+  "Version": "0.2.6",
   "Description": "Planned Parenthood.",
   "UniqueID": "aedenthorn.PlannedParenthood",
   "EntryDll": "PlannedParenthood.dll",
-  "MinimumApiVersion": "3.8.0",
+  "MinimumApiVersion": "4.0.0",
   "ModUpdater": {
     "Repository": "StardewValleyMods",
     "User": "aedenthorn",


### PR DESCRIPTION
Just changes Harmony patches from harmony.patchAll (with annotations) to harmony.patch. 
I've been going down the line making updates for all of my Aedenthorn mods, and I assumed this one was broken. However, when I went to make this commit I realized this was the only change I made; the mod wasn't even broken - I got my old copy and it ran fine. However, the wiki says using patch is better, so since I've done it I might as well push it. This update is not necessary.