### PR TITLE
fix: port Restauranteer to 1.6

### DIFF
--- a/Restauranteer/CodePatches.cs
+++ b/Restauranteer/CodePatches.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Newtonsoft.Json;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.BellsAndWhistles;
 using System;
@@ -9,27 +10,17 @@ using System.Collections.Generic;
 using xTile.Dimensions;
 using xTile.ObjectModel;
 using xTile.Tiles;
-using Object = StardewValley.Object;
 using Rectangle = Microsoft.Xna.Framework.Rectangle;
 
 namespace Restauranteer
 {
     public partial class ModEntry
     {
+        private static int emoteBaseIndex = 424242;
 
-        [HarmonyPatch(typeof(NPC), nameof(NPC.draw))]
-        public class NPC_draw_Patch
+        public static void NPCdraw_Postfix(NPC __instance, SpriteBatch b, float alpha, ref bool __state)
         {
-            private static int emoteBaseIndex = 424242;
-
-            public static void Prefix(NPC __instance, ref bool __state)
-            {
-                if (!Config.ModEnabled || !__instance.IsEmoting || __instance.CurrentEmote != emoteBaseIndex)
-                    return;
-                __state = true;
-                __instance.IsEmoting = false;
-            }
-            public static void Postfix(NPC __instance, SpriteBatch b, float alpha, ref bool __state)
+            try
             {
                 if (!Config.ModEnabled || !__state)
                     return;
@@ -59,13 +50,17 @@ namespace Restauranteer
                     b.Draw(emoteSprite, emotePosition, new Rectangle?(new Rectangle(emoteIndex * 16 % Game1.emoteSpriteSheet.Width, emoteIndex * 16 / emoteSprite.Width * 16, 16, 16)), Color.White, 0f, Vector2.Zero, 4f, SpriteEffects.None, __instance.getStandingPosition().Y / 10000f);
                     b.Draw(Game1.objectSpriteSheet, emotePosition + new Vector2(16, 8), GameLocation.getSourceRectForObject(orderData.dish), Color.White, 0f, Vector2.Zero, 2f, SpriteEffects.None, (__instance.getStandingPosition().Y + 1) / 10000f);
                 }
-
             }
+            catch (Exception ex)
+            {
+                SMonitor.Log($"Failed in {nameof(NPCdraw_Postfix)}:\n{ex}", LogLevel.Error);
+            }
+
         }
-        [HarmonyPatch(typeof(GameLocation), nameof(GameLocation.checkAction))]
-        public class GameLocation_checkAction_Patch
+
+        public static bool GameLocationcheckAction_Prefix(GameLocation __instance, Location tileLocation, xTile.Dimensions.Rectangle viewport, Farmer who, ref bool __result)
         {
-            public static bool Prefix(GameLocation __instance, Location tileLocation, xTile.Dimensions.Rectangle viewport, Farmer who, ref bool __result)
+            try
             {
                 if (!Config.ModEnabled || !Config.RestaurantLocations.Contains(__instance.Name))
                     return true;
@@ -87,46 +82,63 @@ namespace Restauranteer
                 }
                 return true;
             }
-        }
-        [HarmonyPatch(typeof(GameLocation), nameof(GameLocation.performAction))]
-        public class GameLocation_performAction_Patch
-        {
-            public static bool Prefix(GameLocation __instance, string action, Farmer who, Location tileLocation, ref bool __result)
+            catch (Exception ex)
             {
-                if (!Config.ModEnabled || !Config.RestaurantLocations.Contains(__instance.Name) || (action != "kitchen" && action != "restaurant"))
-                    return true;
-                if (Config.RequireEvent && !Game1.player.eventsSeen.Contains("980558"))
-                {
-                    Game1.drawObjectDialogue(SHelper.Translation.Get("low-friendship"));
-                    __result = true;
-                    return false;
-                }
-                var fridge = GetFridge(__instance);
-
-                __instance.ActivateKitchen();
-                //__instance.ActivateKitchen(fridge);
-                __result = true;
-                return false;
+                SMonitor.Log($"Failed in {nameof(GameLocationcheckAction_Prefix)}:\n{ex}", LogLevel.Error);
+                return true;
             }
         }
 
-        [HarmonyPatch(typeof(GameLocation), nameof(GameLocation.UpdateWhenCurrentLocation))]
-        public class GameLocation_UpdateWhenCurrentLocation_Patch
+        public static bool GameLocationPerformAction_Prefix(GameLocation __instance, Location tileLocation, xTile.Dimensions.Rectangle viewport, Farmer who, ref bool __result)
         {
-            public static void Postfix(GameLocation __instance, GameTime time)
+            try
+            {
+                if (!Config.ModEnabled || !Config.RestaurantLocations.Contains(__instance.Name))
+                    return true;
+                Tile tile = __instance.map.GetLayer("Buildings").PickTile(new Location(tileLocation.X * 64, tileLocation.Y * 64), viewport.Size);
+                if (tile != null && tile.Properties.TryGetValue("Action", out PropertyValue property) && property == "DropBox GusFridge")
+                {
+                    if (__instance.performAction(property, who, tileLocation))
+                    {
+
+                        __result = true;
+                        return false;
+                    }
+                    else if (Config.RequireEvent && !Game1.player.eventsSeen.Contains("980558"))
+                    {
+                        Game1.drawObjectDialogue(SHelper.Translation.Get("low-friendship"));
+                        __result = true;
+                        return false;
+                    }
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                SMonitor.Log($"Failed in {nameof(GameLocationPerformAction_Prefix)}:\n{ex}", LogLevel.Error);
+                return true;
+            }
+        }
+
+        public static void GameLocation_UpdateWhenCurrentLocation_Postfix(GameLocation __instance, GameTime time)
+        {
+            try
             {
                 if (!Config.ModEnabled || !Config.RestaurantLocations.Contains(__instance.Name))
                     return;
                 var fridge = GetFridge(__instance);
                 fridge.Value.updateWhenCurrentLocation(time);
-                //fridge.Value.updateWhenCurrentLocation(time, __instance);
             }
+            catch (Exception ex)
+            {
+                SMonitor.Log($"Failed in {nameof(GameLocation_UpdateWhenCurrentLocation_Postfix)}:\n{ex}", LogLevel.Error);
+            }
+
         }
 
-        [HarmonyPatch(typeof(Utility), nameof(Utility.checkForCharacterInteractionAtTile))]
-        public class Utility_checkForCharacterInteractionAtTile_Patch
+        public static bool Utility_checkForCharacterInteractionAtTile_Prefix(Vector2 tileLocation, Farmer who)
         {
-            public static bool Prefix(Vector2 tileLocation, Farmer who)
+            try
             {
                 if (!Config.ModEnabled)
                     return true;
@@ -146,12 +158,16 @@ namespace Restauranteer
                 }
                 return true;
             }
+            catch (Exception ex)
+            {
+                SMonitor.Log($"Failed in {nameof(Utility_checkForCharacterInteractionAtTile_Prefix)}:\n{ex}", LogLevel.Error);
+                return true;
+            }
         }
 
-        [HarmonyPatch(typeof(NPC), nameof(NPC.tryToReceiveActiveObject))]
-        public class NPC_tryToReceiveActiveObject_Patch
+        public static bool NPC_tryToReceiveActiveObject_Prefix(NPC __instance, Farmer who)
         {
-            public static bool Prefix(NPC __instance, Farmer who)
+            try
             {
                 if (!Config.ModEnabled || !Config.RestaurantLocations.Contains(__instance.currentLocation.Name) || !__instance.modData.TryGetValue(orderKey, out string data))
                     return true;
@@ -245,31 +261,40 @@ namespace Restauranteer
                 }
                 return true;
             }
+            catch (Exception ex)
+            {
+                SMonitor.Log($"Failed in {nameof(NPC_tryToReceiveActiveObject_Prefix)}:\n{ex}", LogLevel.Error);
+                return true;
+            }
         }
 
-        /*
-         * TODO: Find method 
-        [HarmonyPatch(typeof(Utility), nameof(Utility.getSaloonStock))]
-        public class Utility_getSaloonStock_Patch
+
+    }
+    /*
+     * 
+
+    /*
+     * TODO: Find method 
+    [HarmonyPatch(typeof(Utility), nameof(Utility.getSaloonStock))]
+    public class Utility_getSaloonStock_Patch
+    {
+        public static void Postfix(Dictionary<ISalable, int[]> __result)
         {
-            public static void Postfix(Dictionary<ISalable, int[]> __result)
+            if (!Config.ModEnabled || !Config.SellCurrentRecipes)
+                return;
+            foreach (var npc in Game1.getLocationFromName("Saloon").characters)
             {
-                if (!Config.ModEnabled || !Config.SellCurrentRecipes)
-                    return;
-                foreach (var npc in Game1.getLocationFromName("Saloon").characters)
+                if (npc.modData.TryGetValue(orderKey, out string dataString))
                 {
-                    if (npc.modData.TryGetValue(orderKey, out string dataString))
+                    var data = JsonConvert.DeserializeObject<OrderData>(dataString);
+                    if (!Game1.player.cookingRecipes.ContainsKey(data.dishName))
                     {
-                        var data = JsonConvert.DeserializeObject<OrderData>(dataString);
-                        if (!Game1.player.cookingRecipes.ContainsKey(data.dishName))
-                        {
-                            Utility.AddStock(__result, new Object(data.dish, 1, true, -1, 0), data.dishPrice, -1);
-                        }
+                        Utility.AddStock(__result, new Object(data.dish, 1, true, -1, 0), data.dishPrice, -1);
                     }
                 }
             }
         }
-        */
-
     }
+    */
+
 }

--- a/Restauranteer/ModEntry.cs
+++ b/Restauranteer/ModEntry.cs
@@ -28,7 +28,7 @@ namespace Restauranteer
         public static ModConfig Config;
 
         public static ModEntry context;
-        
+
         public static string orderKey = "aedenthorn.Restauranteer/order";
         public static string fridgeKey = "aedenthorn.Restauranteer/fridge";
         public static Texture2D emoteSprite;
@@ -79,7 +79,7 @@ namespace Restauranteer
                                 Vector2 v = new Vector2(x, y);
                                 if (Config.AddFridgeObjects && !l.objects.TryGetValue(v, out Object obj))
                                 {
-                                    Chest fridge = new Chest(216, v, 217, 2)
+                                    Chest fridge = new Chest("216", v, 217, 2)
                                     {
                                         shakeTimer = 50
                                     };
@@ -100,7 +100,7 @@ namespace Restauranteer
 
         private void GameLoop_OneSecondUpdateTicked(object sender, StardewModdingAPI.Events.OneSecondUpdateTickedEventArgs e)
         {
-            if(Config.ModEnabled && Context.IsPlayerFree && Config.RestaurantLocations.Contains(Game1.player.currentLocation.Name) && (!Config.RequireEvent || Game1.player.eventsSeen.Contains(980558)))
+            if (Config.ModEnabled && Context.IsPlayerFree && Config.RestaurantLocations.Contains(Game1.player.currentLocation.Name) && (!Config.RequireEvent || Game1.player.eventsSeen.Contains("980558")))
             {
                 UpdateOrders();
             }
@@ -115,7 +115,7 @@ namespace Restauranteer
                 e.Edit(delegate (IAssetData data)
                 {
                     var dict = data.AsDictionary<string, string>();
-                    if(dict.Data.TryGetValue(Config.EventKey, out string str))
+                    if (dict.Data.TryGetValue(Config.EventKey, out string str))
                     {
                         dict.Data[Config.EventKey] = str.Replace(Config.EventReplacePart, string.Format(Config.EventReplaceWith, Helper.Translation.Get("gus-event-string")));
                     }
@@ -130,7 +130,7 @@ namespace Restauranteer
                     {
                         map.PatchMap(Helper.ModContent.Load<Map>(Path.Combine("assets", "SaloonKitchen.tmx")), targetArea: new Microsoft.Xna.Framework.Rectangle(10, 12, 8, 5), patchMode: PatchMapMode.Replace);
                     }
-                    foreach(var tile in Config.KitchenTiles)
+                    foreach (var tile in Config.KitchenTiles)
                     {
                         try
                         {
@@ -161,8 +161,8 @@ namespace Restauranteer
             object obj = Helper.ModRegistry.GetApi("blueberry.LoveOfCooking");
             if (obj is not null)
             {
-                harmony.Patch( 
-                    original: AccessTools.Constructor(obj.GetType().Assembly.GetType("LoveOfCooking.Objects.CookingMenu"), new Type[] { typeof(List<CraftingRecipe>), typeof(List<Chest>), typeof(string)  }),
+                harmony.Patch(
+                    original: AccessTools.Constructor(obj.GetType().Assembly.GetType("LoveOfCooking.Objects.CookingMenu"), new Type[] { typeof(List<CraftingRecipe>), typeof(List<Chest>), typeof(string) }),
                     prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.LoveOfCooking_CookingMenu_Prefix))
                 );
             }
@@ -231,19 +231,19 @@ namespace Restauranteer
                 mod: ModManifest,
                 name: () => "Order Chance / s",
                 getValue: () => Config.OrderChance + "",
-                setValue: delegate(string value) { if (float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out float val)){ Config.OrderChance = val; } }
+                setValue: delegate (string value) { if (float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out float val)) { Config.OrderChance = val; } }
             );
             configMenu.AddTextOption(
                 mod: ModManifest,
                 name: () => "Loved Dish Order Chance",
                 getValue: () => Config.LovedDishChance + "",
-                setValue: delegate(string value) { if (float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out float val)){ Config.LovedDishChance = val; } }
+                setValue: delegate (string value) { if (float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out float val)) { Config.LovedDishChance = val; } }
             );
             configMenu.AddTextOption(
                 mod: ModManifest,
                 name: () => "Price Multiplier",
                 getValue: () => Config.PriceMarkup + "",
-                setValue: delegate(string value) { if (float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out float val)){ Config.PriceMarkup = val; } }
+                setValue: delegate (string value) { if (float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out float val)) { Config.PriceMarkup = val; } }
             );
             configMenu.AddNumberOption(
                 mod: ModManifest,
@@ -255,7 +255,7 @@ namespace Restauranteer
                 mod: ModManifest,
                 name: () => "Loved Friendship Change",
                 getValue: () => Config.LovedFriendshipChange,
-                setValue: value => Config.LovedFriendshipChange= value
+                setValue: value => Config.LovedFriendshipChange = value
             );
             configMenu.AddNumberOption(
                 mod: ModManifest,
@@ -270,9 +270,9 @@ namespace Restauranteer
             if (!Config.ModEnabled || !Config.RestaurantLocations.Contains(Game1.currentLocation.Name))
                 return;
             var fridge = GetFridge(Game1.currentLocation);
-            if(materialContainers is null)
+            if (materialContainers is null)
                 materialContainers = new List<Chest>();
-            materialContainers.Add( fridge );
+            materialContainers.Add(fridge.Value);
         }
     }
 }

--- a/Restauranteer/Restauranteer.csproj
+++ b/Restauranteer/Restauranteer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<EnableHarmony>true</EnableHarmony>
 	<Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>


### PR DESCRIPTION
I had updated Restauranteer to 1.6. While the packages were right, there were a few methods that were broken. To be honest, I wasn't quite sure about the modern equivalent of all of them. However it does compile.


I could not figure out the reactions and there was an issue trying to find the method that was Harmony patched.  I more or less guessed how the scrolling text was supposed to preform and did my best to find the right type for the items. 

Lastly, I had not yet manually tested it _yet_. My hope was to get the bare minimum working before anything else. 