### PR TITLE
[Instant Building Construction and Upgrade] Add support for custom buildings

### DIFF
--- a/InstantBuildingConstruction/Compatibility.cs
+++ b/InstantBuildingConstruction/Compatibility.cs
@@ -1,0 +1,7 @@
+﻿namespace InstantBuildingConstructionAndUpgrade
+{
+	internal class CompatibilityUtility
+	{
+		internal static readonly bool IsSolidFoundationsLoaded = ModEntry.SHelper.ModRegistry.IsLoaded("PeacefulEnd.SolidFoundations");
+	}
+}

--- a/InstantBuildingConstruction/ConsoleCommands.cs
+++ b/InstantBuildingConstruction/ConsoleCommands.cs
@@ -1,0 +1,20 @@
+﻿using StardewModdingAPI;
+
+namespace InstantBuildingConstructionAndUpgrade
+{
+	public partial class ModEntry
+	{
+		internal void RegisterConsoleCommands()
+		{
+			SHelper.ConsoleCommands.Add("ibcu_reload", "Reapply modifications to building data and farmhouse renovation data.", IBCU_reload);
+		}
+
+		private void IBCU_reload(string command, string[] args)
+		{
+			SHelper.GameContent.InvalidateCache(asset => asset.Name.IsEquivalentTo("Data/Buildings"));
+			SHelper.GameContent.InvalidateCache(asset => asset.Name.IsEquivalentTo("Data/HomeRenovations"));
+			SHelper.GameContent.InvalidateCache(asset => asset.NameWithoutLocale.IsEquivalentTo("Strings/Locations"));
+			SMonitor.Log("Modifications to building data and farmhouse renovation data reapplied.", LogLevel.Info);
+		}
+	}
+}

--- a/InstantBuildingConstruction/Methods.cs
+++ b/InstantBuildingConstruction/Methods.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+
+namespace InstantBuildingConstructionAndUpgrade
+{
+	public partial class ModEntry
+	{
+		public static void ExecuteCommand(string command)
+		{
+			Type sCoreType = Type.GetType("StardewModdingAPI.Framework.SCore, StardewModdingAPI");
+			Type commandQueueType = Type.GetType("StardewModdingAPI.Framework.CommandQueue, StardewModdingAPI");
+			object instance = sCoreType.GetProperty("Instance", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null);
+			object rawCommandQueue = sCoreType.GetField("RawCommandQueue", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(instance);
+			MethodInfo addMethod = commandQueueType.GetMethod("Add", BindingFlags.Instance | BindingFlags.Public);
+
+			addMethod.Invoke(rawCommandQueue, new object[] { command });
+		}
+	}
+}

--- a/InstantBuildingConstruction/ModEntry.cs
+++ b/InstantBuildingConstruction/ModEntry.cs
@@ -90,7 +90,7 @@ namespace InstantBuildingConstructionAndUpgrade
 							buildingData.BuildMaterials = new();
 						}
 					}
-				});
+				}, AssetEditPriority.Late);
 			}
 			if (Config.FreeConstructionAndUpgrade)
 			{
@@ -104,7 +104,7 @@ namespace InstantBuildingConstructionAndUpgrade
 						{
 							homeRenovation.Price = 0;
 						}
-					});
+					}, AssetEditPriority.Late);
 				}
 				if (e.NameWithoutLocale.IsEquivalentTo("Strings/Locations"))
 				{
@@ -142,6 +142,8 @@ namespace InstantBuildingConstructionAndUpgrade
 
 		private void GameLoop_GameLaunched(object sender, GameLaunchedEventArgs e)
 		{
+			RegisterConsoleCommands();
+
 			// Get Generic Mod Config Menu's API
 			IGenericModConfigMenuApi gmcm = Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
 
@@ -152,9 +154,11 @@ namespace InstantBuildingConstructionAndUpgrade
 					mod: ModManifest,
 					reset: () => Config = new ModConfig(),
 					save: () => {
-						SHelper.GameContent.InvalidateCache(asset => asset.Name.IsEquivalentTo("Data/Buildings"));
-						SHelper.GameContent.InvalidateCache(asset => asset.Name.IsEquivalentTo("Data/HomeRenovations"));
-						SHelper.GameContent.InvalidateCache(asset => asset.NameWithoutLocale.IsEquivalentTo("Strings/Locations"));
+						if (CompatibilityUtility.IsSolidFoundationsLoaded)
+						{
+							ExecuteCommand("sf_reload");
+						}
+						ExecuteCommand("ibcu_reload");
 						Helper.WriteConfig(Config);
 					}
 				);


### PR DESCRIPTION
Added support for custom buildings by adjusting the asset edit priority. For compatibility with [Solid Foundations](https://www.nexusmods.com/stardewvalley/mods/12311), a new console command, `ibcu_reload`, which invalidates assets, was introduced. Thus, when GMCM settings are changed, `sf_reload` and `ibcu_reload` are queued in this order to ensure that asset invalidation occurs only after Solid Foundations buildings have been reloaded.