### PR TITLE
[Moolah Money Mod] Add compatibility with Ship Anything and Sell Everything

### DIFF
--- a/MoolahMoneyMod/CodePatches.cs
+++ b/MoolahMoneyMod/CodePatches.cs
@@ -157,7 +157,7 @@ namespace MoolahMoneyMod
 
 		public class ShippingMenu_Patch
 		{
-			public static void Prefix(ShippingMenu __instance)
+			public static void Postfix(List<List<Item>> ___categoryItems)
 			{
 				if (!Config.ModEnabled)
 					return;
@@ -166,18 +166,20 @@ namespace MoolahMoneyMod
 				itemValues.Value = new();
 				singleItemValues.Value = new();
 				moneyDialDataList.Value = new() { new(), new(), new(), new(), new(), new() };
-				foreach (Item item in Game1.player.displayedShippedItems)
+				for (int category = 0; category < 5; category++)
 				{
-					if (item is Object obj)
+					foreach (Item item in ___categoryItems[category])
 					{
-						int category = __instance.getCategoryIndexForObject(obj);
-						int sell_to_store_price = obj.sellToStorePrice(-1L);
-						BigInteger price = new BigInteger(sell_to_store_price) * obj.Stack;
+						if (item is not null)
+						{
+							int sell_to_store_price = item.sellToStorePrice(-1L);
+							BigInteger price = new BigInteger(sell_to_store_price) * item.Stack;
 
-						categoryTotals.Value[category] += price;
-						categoryTotals.Value[5] += price;
-						itemValues.Value[item] = price;
-						singleItemValues.Value[item] = sell_to_store_price;
+							categoryTotals.Value[category] += price;
+							categoryTotals.Value[5] += price;
+							itemValues.Value[item] = price;
+							singleItemValues.Value[item] = sell_to_store_price;
+						}
 					}
 				}
 			}

--- a/MoolahMoneyMod/ModEntry.cs
+++ b/MoolahMoneyMod/ModEntry.cs
@@ -61,7 +61,7 @@ namespace MoolahMoneyMod
 				);
 				harmony.Patch(
 					original: AccessTools.Method(typeof(Game1), "_newDayAfterFade"),
-					prefix: new HarmonyMethod(typeof(Game1_newDayAfterFade_Patch), nameof(Game1_newDayAfterFade_Patch.Prefix))
+					prefix: new HarmonyMethod(typeof(Game1_newDayAfterFade_Patch), nameof(Game1_newDayAfterFade_Patch.Prefix)) { priority = Priority.Last }
 				);
 				harmony.Patch(
 					original: AccessTools.Method(typeof(DayTimeMoneyBox), nameof(DayTimeMoneyBox.drawMoneyBox)),
@@ -77,7 +77,7 @@ namespace MoolahMoneyMod
 				);
 				harmony.Patch(
 					original: AccessTools.Constructor(typeof(ShippingMenu), new Type[] { typeof(IList<Item>) }),
-					prefix: new HarmonyMethod(typeof(ShippingMenu_Patch), nameof(ShippingMenu_Patch.Prefix))
+					postfix: new HarmonyMethod(typeof(ShippingMenu_Patch), nameof(ShippingMenu_Patch.Postfix))
 				);
 				harmony.Patch(
 					original: AccessTools.Method(typeof(ShippingMenu), nameof(ShippingMenu.draw), new Type[] { typeof(SpriteBatch) }),


### PR DESCRIPTION
Added compatibility with [Ship Anything](https://www.nexusmods.com/stardewvalley/mods/3782) and [Sell Everything](https://www.nexusmods.com/stardewvalley/mods/43670), two mods that allow items which normally can't be shipped, to be sold through the shipping bin. This fixes the "[The item's selling price becomes 0](https://www.nexusmods.com/stardewvalley/mods/15123?tab=bugs#issue_1077796)" bug reported on Nexus Mods by @hbnthtsk-rgb.