### PR TITLE
Removed extra ModEnabled option from config menu

### DIFF
--- a/LightSwitches/ModEntry.cs
+++ b/LightSwitches/ModEntry.cs
@@ -126,13 +126,7 @@ namespace LightSwitches
                     reset: () => Config = new ModConfig(),
                     save: () => Helper.WriteConfig(Config)
                 );
-
-                configMenu.AddBoolOption(
-                    mod: ModManifest,
-                    name: () => SHelper.Translation.Get("ModEnabled"),
-                    getValue: () => Config.ModEnabled,
-                    setValue: value => Config.ModEnabled = value
-                );
+                
                 var props = typeof(ModConfig).GetProperties().ToArray();
                 var configMenuExt = Helper.ModRegistry.GetApi<IGMCMOptionsAPI>("jltaylor-us.GMCMOptions");
 


### PR DESCRIPTION
"Mod Enabled" was being duplicated, it doesn't need to be initialized as it is already in the ModConfig properties.