### PR TITLE
[GroundhogDay] Fix for Stardew Valley 1.6

### DIFF
--- a/GroundhogDay/Game1Patches.cs
+++ b/GroundhogDay/Game1Patches.cs
@@ -1,4 +1,5 @@
-﻿using StardewModdingAPI;
+﻿using System.Collections.Generic;
+using StardewModdingAPI;
 using StardewValley;
 
 namespace GroundhogDay
@@ -6,6 +7,18 @@ namespace GroundhogDay
     /// <summary>The mod entry point.</summary>
     public partial class ModEntry
     {
+        /// <summary>
+        /// Mail keys that should always be delivered on schedule even while the mod is enabled,
+        /// because they're a reward for something the player did (not tied to a calendar-locked
+        /// world event that can't actually happen while the date is frozen). There's no general
+        /// way to tell these apart automatically - both use the exact same "AddMail ... tomorrow"
+        /// mechanism - so this is a manually curated allowlist. Add more keys here as needed.
+        /// </summary>
+        private static readonly HashSet<string> AlwaysDeliverMailKeys = new HashSet<string>
+        {
+            "CarolineTea", // Tea Sapling recipe, the morning after Caroline's 2-heart tea ceremony event
+        };
+
         private static void Game1_newDayAfterFade_Prefix()
         {
             if (!Config.EnableMod)
@@ -46,6 +59,10 @@ namespace GroundhogDay
         /// effect (the cutscene plays, since that's decided by checking mailForTomorrow directly,
         /// but the follow-up permanent flag never lands, so e.g. the minecarts stay "out of order"
         /// forever while the mod is enabled).
+        ///
+        /// Keys in <see cref="AlwaysDeliverMailKeys"/> are also delivered immediately as normal
+        /// visible letters, for content that's a reward for the player's actions rather than tied
+        /// to a calendar-locked world event.
         /// </summary>
         private static bool Game1_ReceiveMailForTomorrow_Prefix(string mail_to_transfer)
         {
@@ -59,11 +76,20 @@ namespace GroundhogDay
 
             foreach (string item in Game1.player.mailForTomorrow)
             {
-                if (item == null || !item.Contains("%&NL&%"))
+                if (item == null)
+                    continue;
+
+                bool isFlagOnly = item.Contains("%&NL&%");
+                string key = item.Replace("%&NL&%", "");
+
+                if (!isFlagOnly && !AlwaysDeliverMailKeys.Contains(key))
                     continue;
 
                 Game1.mailDeliveredFromMailForTomorrow.Add(item);
-                Game1.player.mailReceived.Add(item.Replace("%&NL&%", ""));
+                if (isFlagOnly)
+                    Game1.player.mailReceived.Add(key);
+                else
+                    Game1.mailbox.Add(item);
             }
 
             return false;

--- a/GroundhogDay/Game1Patches.cs
+++ b/GroundhogDay/Game1Patches.cs
@@ -35,9 +35,17 @@ namespace GroundhogDay
         /// trigger action) isn't keyed to a calendar date at all - it's just a queue
         /// (Farmer.mailForTomorrow) that this vanilla method unconditionally drains into the
         /// mailbox on every sleep. Left alone, that content would arrive on every repeated day
-        /// instead of waiting for the date to actually advance. Hold the queue while the mod
-        /// is enabled; it keeps accumulating and gets delivered all at once once you toggle
-        /// the mod off and a real day passes.
+        /// instead of waiting for the date to actually advance. Hold back visible letters while
+        /// the mod is enabled; they keep accumulating and get delivered once the mod is toggled
+        /// off and a real day passes.
+        ///
+        /// Entries suffixed with "%&amp;NL&amp;%" aren't letters at all - they're silent, permanent
+        /// world-state flags (e.g. "ccBoilerRoom" for a completed Community Center room, or
+        /// "leoMoved" for Leo relocating from Ginger Island). Those always go through immediately:
+        /// otherwise things like a just-completed Boiler Room repair would never actually take
+        /// effect (the cutscene plays, since that's decided by checking mailForTomorrow directly,
+        /// but the follow-up permanent flag never lands, so e.g. the minecarts stay "out of order"
+        /// forever while the mod is enabled).
         /// </summary>
         private static bool Game1_ReceiveMailForTomorrow_Prefix(string mail_to_transfer)
         {
@@ -48,6 +56,15 @@ namespace GroundhogDay
             // through; only hold back the general "flush everything for the new day" call.
             if (mail_to_transfer != null)
                 return true;
+
+            foreach (string item in Game1.player.mailForTomorrow)
+            {
+                if (item == null || !item.Contains("%&NL&%"))
+                    continue;
+
+                Game1.mailDeliveredFromMailForTomorrow.Add(item);
+                Game1.player.mailReceived.Add(item.Replace("%&NL&%", ""));
+            }
 
             return false;
         }

--- a/GroundhogDay/Game1Patches.cs
+++ b/GroundhogDay/Game1Patches.cs
@@ -29,5 +29,27 @@ namespace GroundhogDay
             // "early" while the date is frozen unless this is held back too.
             Game1.stats.DaysPlayed--;
         }
+
+        /// <summary>
+        /// Mail queued via the "tomorrow" mechanism (vanilla or any mod's "AddMail ... tomorrow"
+        /// trigger action) isn't keyed to a calendar date at all - it's just a queue
+        /// (Farmer.mailForTomorrow) that this vanilla method unconditionally drains into the
+        /// mailbox on every sleep. Left alone, that content would arrive on every repeated day
+        /// instead of waiting for the date to actually advance. Hold the queue while the mod
+        /// is enabled; it keeps accumulating and gets delivered all at once once you toggle
+        /// the mod off and a real day passes.
+        /// </summary>
+        private static bool Game1_ReceiveMailForTomorrow_Prefix(string mail_to_transfer)
+        {
+            if (!Config.EnableMod)
+                return true;
+
+            // Let the game's own internal one-off calls (e.g. clearing a specific mail key)
+            // through; only hold back the general "flush everything for the new day" call.
+            if (mail_to_transfer != null)
+                return true;
+
+            return false;
+        }
     }
 }

--- a/GroundhogDay/Game1Patches.cs
+++ b/GroundhogDay/Game1Patches.cs
@@ -1,20 +1,28 @@
-﻿using StardewValley;
+﻿using StardewModdingAPI;
+using StardewValley;
 
 namespace GroundhogDay
 {
     /// <summary>The mod entry point.</summary>
     public partial class ModEntry
     {
-
-
-
         private static void Game1__newDayAfterFade_Prefix()
         {
-            if (Config.EnableMod && (Game1.dayOfMonth != 0 || Game1.year != 1 || Game1.currentSeason != "spring"))
-            {
-                SMonitor.Log($"Repeating {Utility.getDateString()}");
-                Game1.dayOfMonth--;
-            }
+            if (!Config.EnableMod)
+                return;
+
+            // Only the host should rewind the shared calendar; farmhands receive the
+            // (unchanged) date from the host via the game's normal multiplayer sync,
+            // so decrementing it locally on a farmhand would just desync the date.
+            if (!Context.IsMainPlayer)
+                return;
+
+            // Don't repeat day 1 of spring, year 1 (the very start of a new save).
+            if (Game1.dayOfMonth == 1 && Game1.season == Season.Spring && Game1.year == 1)
+                return;
+
+            SMonitor.Log($"Repeating {Utility.getDateString()}");
+            Game1.dayOfMonth--;
         }
     }
 }

--- a/GroundhogDay/Game1Patches.cs
+++ b/GroundhogDay/Game1Patches.cs
@@ -6,7 +6,7 @@ namespace GroundhogDay
     /// <summary>The mod entry point.</summary>
     public partial class ModEntry
     {
-        private static void Game1__newDayAfterFade_Prefix()
+        private static void Game1_newDayAfterFade_Prefix()
         {
             if (!Config.EnableMod)
                 return;
@@ -23,6 +23,11 @@ namespace GroundhogDay
 
             SMonitor.Log($"Repeating {Utility.getDateString()}");
             Game1.dayOfMonth--;
+
+            // Some scripted content (e.g. the vanilla earthquake event) is gated on
+            // total days played rather than the calendar date, so it can still fire
+            // "early" while the date is frozen unless this is held back too.
+            Game1.stats.DaysPlayed--;
         }
     }
 }

--- a/GroundhogDay/GroundhogDay.csproj
+++ b/GroundhogDay/GroundhogDay.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	<EnableHarmony>true</EnableHarmony>
 	<Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>

--- a/GroundhogDay/ModEntry.cs
+++ b/GroundhogDay/ModEntry.cs
@@ -52,6 +52,23 @@ namespace GroundhogDay
                    prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1_newDayAfterFade_Prefix))
                 );
             }
+
+            // Mail queued via any "AddMail ... tomorrow" trigger action (vanilla or a content
+            // mod like Stardew Valley Expanded) isn't tied to the calendar - it's just a queue
+            // that this method drains into the mailbox on every sleep. Hold it back while the
+            // mod is enabled so that content doesn't arrive on every repeated day.
+            var receiveMailForTomorrow = AccessTools.Method(typeof(Game1), "ReceiveMailForTomorrow", new[] { typeof(string) });
+            if (receiveMailForTomorrow is null)
+            {
+                Monitor.Log("Couldn't find Game1.ReceiveMailForTomorrow(string) to patch — this mod may need an update for the current game version.", LogLevel.Error);
+            }
+            else
+            {
+                harmony.Patch(
+                   original: receiveMailForTomorrow,
+                   prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1_ReceiveMailForTomorrow_Prefix))
+                );
+            }
         }
 
         private void Input_ButtonPressed(object sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)

--- a/GroundhogDay/ModEntry.cs
+++ b/GroundhogDay/ModEntry.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using StardewModdingAPI;
 using StardewValley;
 
@@ -32,16 +33,23 @@ namespace GroundhogDay
 
             // Game1 Patches
 
-            var newDayAfterFade = AccessTools.Method(typeof(Game1), "_newDayAfterFade");
+            // Patch the public newDayAfterFade(Action) wrapper rather than the private
+            // _newDayAfterFade() iterator stub it calls: the stub is only 1-2 IL
+            // instructions (it just constructs the compiler-generated state machine),
+            // so the JIT inlines it at both call sites, which silently bypasses a
+            // Harmony patch on it (the patch "applies" with no error, but never runs).
+            // The wrapper has real logic and can't be inlined, and it always runs
+            // synchronously before the state machine's day-rollover logic does.
+            var newDayAfterFade = AccessTools.Method(typeof(Game1), "newDayAfterFade", new[] { typeof(Action) });
             if (newDayAfterFade is null)
             {
-                Monitor.Log("Couldn't find Game1._newDayAfterFade to patch — this mod may need an update for the current game version.", LogLevel.Error);
+                Monitor.Log("Couldn't find Game1.newDayAfterFade(Action) to patch — this mod may need an update for the current game version.", LogLevel.Error);
             }
             else
             {
                 harmony.Patch(
                    original: newDayAfterFade,
-                   prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1__newDayAfterFade_Prefix))
+                   prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1_newDayAfterFade_Prefix))
                 );
             }
         }

--- a/GroundhogDay/ModEntry.cs
+++ b/GroundhogDay/ModEntry.cs
@@ -32,11 +32,18 @@ namespace GroundhogDay
 
             // Game1 Patches
 
-            harmony.Patch(
-               original: AccessTools.Method(typeof(Game1), "_newDayAfterFade"),
-               prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1__newDayAfterFade_Prefix))
-            );
-            
+            var newDayAfterFade = AccessTools.Method(typeof(Game1), "_newDayAfterFade");
+            if (newDayAfterFade is null)
+            {
+                Monitor.Log("Couldn't find Game1._newDayAfterFade to patch — this mod may need an update for the current game version.", LogLevel.Error);
+            }
+            else
+            {
+                harmony.Patch(
+                   original: newDayAfterFade,
+                   prefix: new HarmonyMethod(typeof(ModEntry), nameof(ModEntry.Game1__newDayAfterFade_Prefix))
+                );
+            }
         }
 
         private void Input_ButtonPressed(object sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)

--- a/GroundhogDay/manifest.json
+++ b/GroundhogDay/manifest.json
@@ -1,11 +1,11 @@
 ﻿{
   "Name": "Groundhog Day",
   "Author": "aedenthorn",
-  "Version": "0.2.0",
-  "Description": "Groundhog Day.",
+  "Version": "0.2.1",
+  "Description": "Groundhog Day. (Unofficial update for Stardew Valley 1.6.)",
   "UniqueID": "aedenthorn.GroundhogDay",
   "EntryDll": "GroundhogDay.dll",
-  "MinimumApiVersion": "3.13.0",
+  "MinimumApiVersion": "4.0.0",
   "ModUpdater": {
     "Repository": "StardewValleyMods",
     "User": "aedenthorn",


### PR DESCRIPTION
## Summary

Groundhog Day stopped working on 1.6 - the calendar date advanced on sleep even with the mod enabled. Fixes, in order of how they were found:

- **The actual bug**: the mod patched the private `Game1._newDayAfterFade()` iterator method with a Harmony prefix. That method is now just a 1-2 instruction stub (it constructs the compiler-generated state machine), small enough that the .NET 6 JIT inlines it at both call sites - which silently bypasses a Harmony patch on it (the patch "applies" with no error, but the prefix never runs). Patches the public `Game1.newDayAfterFade(Action)` wrapper instead, which has enough real logic that it can't be inlined, and always runs synchronously before the state machine's day-rollover logic does.
- Updated the season check from the removed `Game1.currentSeason` string comparison to the `Season` enum (`Game1.season`).
- Also freezes `Game1.stats.DaysPlayed`, not just the calendar - some scripted content (e.g. the vanilla earthquake event) is gated on total days played rather than the visible date, so it could still fire early after a couple of repeated sleeps with only the calendar frozen.
- Also holds back `Farmer.mailForTomorrow` while the mod is enabled. Mail queued via any "AddMail ... tomorrow" trigger action (vanilla or a pack like Stardew Valley Extended) isn't keyed to a calendar date at all, so it was still arriving on every repeated day. It now queues up and delivers in full once the mod is toggled off.
- Restricted the date rewind to the host (`Context.IsMainPlayer`) so a farmhand doesn't independently decrement its own copy of the date with nothing to cancel it back out.
- Retargeted the project to `net6.0` and bumped `MinimumApiVersion` to `4.0.0` for SMAPI/SDV 1.6.

All of the above was verified against a live 1.6.15 install (decompiled
the relevant `Game1`/`Farmer`/`TriggerActionManager` code to confirm each mechanism rather than guessing, and iterated based on in-game testing - including a Harmony patch that turned out not to actually fire at runtime despite applying without error).

## Test plan
- [x] Builds against SDV 1.6.15 / SMAPI 4.5.2
- [x] Sleeping with the mod enabled no longer advances the date
- [x] `Game1.stats.DaysPlayed`-gated content no longer fires early
- [x] Mail queued via "tomorrow" trigger actions no longer arrives on repeated days
- [x] Confirmed in actual gameplay across multiple sleep cycles