### PR TITLE
[Moolah Money Mod] Fix money resetting to zero when a mid-day gain caused the total to exceed the int32 limit

### DIFF
--- a/MoolahMoneyMod/CodePatches.cs
+++ b/MoolahMoneyMod/CodePatches.cs
@@ -26,12 +26,13 @@ namespace MoolahMoneyMod
 					return;
 
 				BigInteger moolah = 0;
+				int delta = unchecked(value - __instance._money);
 
 				if (__instance.modData.TryGetValue(moolahKey, out string moolahString))
 				{
 					moolah = BigInteger.Parse(moolahString);
 				}
-				value = StoreOverflowAndClampMoney(__instance, value + moolah);
+				value = StoreOverflowAndClampMoney(__instance, __instance._money + moolah + delta);
 			}
 		}
 


### PR DESCRIPTION
Fixed an issue where money would reset to zero when a mid-day gain (e.g., a reward for a special order) caused the total to exceed the `int32` limit. This fixes the "[Any midday money gains over int32 limit resets money to zero](https://www.nexusmods.com/stardewvalley/mods/15123?tab=bugs#issue_1124486)" bug reported on Nexus Mods by @scriptsforweirdos.

Note: This is likely a regression introduced by my unofficial update.